### PR TITLE
chore: add OSS hygiene files (CONTRIBUTING, SECURITY, templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,55 @@
+---
+name: Bug report
+about: Something in this repo (the binary distribution, examples, or docs) is broken
+title: ''
+labels: bug
+---
+
+<!--
+Heads up: the bitHumanKit *source* is private. This template is for problems
+with what's published in THIS repo: the binary release artifact, Package.swift,
+the Examples/, the docs/, or the Python wheel packaging.
+
+For runtime SDK bugs (lipsync, audio, model loading, API behavior), please
+email support@bithuman.ai — those engineers will reach the right team faster
+than a public issue here can.
+
+For security issues, see SECURITY.md — DO NOT file a public issue.
+-->
+
+### What's broken
+
+A clear, one-paragraph description.
+
+### Where it's broken
+
+- [ ] `Package.swift` / binaryTarget / release artifact
+- [ ] An example under `Examples/`
+- [ ] Documentation under `docs/`
+- [ ] Python wheel packaging
+- [ ] Other (describe)
+
+### Environment
+
+- bitHumanKit version (tag or `Package.resolved` entry):
+- macOS / iOS / iPadOS version:
+- Xcode version:
+- Hardware (e.g. M3 MacBook Pro 14", iPhone 16 Pro):
+
+### Steps to reproduce
+
+1.
+2.
+3.
+
+### Expected behavior
+
+What you thought would happen.
+
+### Actual behavior
+
+What actually happened. Logs, screenshots, or a sample project link are very welcome.
+
+### Anything else?
+
+Anything we should know — workarounds you found, recent changes on your end, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: SDK runtime questions & bugs
+    url: mailto:support@bithuman.ai
+    about: The bitHumanKit source is private. For lipsync, audio, model loading, or API behavior, email support@bithuman.ai — your report reaches the engineers faster than a public issue here.
+  - name: API keys, billing, credits
+    url: mailto:support@bithuman.ai
+    about: Account and billing questions — please email support, not GitHub.
+  - name: Documentation
+    url: https://docs.bithuman.ai
+    about: Full SDK docs, quickstarts, and deployment guides.
+  - name: Security disclosure
+    url: https://github.com/bithuman-product/bithuman-sdk-public/blob/main/SECURITY.md
+    about: Found a security issue? Please email security@bithuman.ai instead of filing a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,36 @@
+---
+name: Feature request
+about: Suggest an improvement to the examples, docs, or packaging
+title: ''
+labels: enhancement
+---
+
+<!--
+This template is for changes we can actually merge from a PR — improvements to
+Examples/, docs/, packaging, or repo metadata.
+
+For SDK API or runtime feature requests (new VoiceChat options, new TTS engines,
+hardware support, etc.), please email support@bithuman.ai or post in our
+community forum. The SDK source is private, so feature work happens there.
+-->
+
+### Use case
+
+What are you trying to do? A short story is more useful than an abstract description.
+
+### Proposal
+
+What would you like added or changed?
+
+- [ ] New example under `Examples/`
+- [ ] New / improved docs page
+- [ ] Packaging improvement (SwiftPM, Python wheel, release flow)
+- [ ] Other
+
+### Alternatives considered
+
+What did you try first, and why didn't it work?
+
+### Are you willing to PR this?
+
+If yes, great — see [CONTRIBUTING.md](../../CONTRIBUTING.md) for what we accept.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+<!--
+Thanks for sending a PR! A few notes before you submit:
+
+- This repo accepts PRs for Examples/, docs/, README, and packaging metadata.
+- PRs that bump SDK versions, edit binaryTarget URLs, or change release
+  artifacts will usually be closed — those are managed by release automation.
+- See CONTRIBUTING.md for the full picture.
+-->
+
+## What this changes
+
+A one-paragraph summary. Link the issue this fixes if there is one (`Fixes #123`).
+
+## Why
+
+What problem does this solve, or what gap does it fill?
+
+## Area
+
+- [ ] `Examples/`
+- [ ] `docs/`
+- [ ] `README.md` / repo metadata
+- [ ] Packaging (`Package.swift`, Python wheel)
+- [ ] Other
+
+## How I tested it
+
+- [ ] Built locally (Xcode version: ____)
+- [ ] Ran the example end-to-end on (hardware: ____)
+- [ ] Verified docs render with `mintlify dev`
+- [ ] N/A — docs/text-only change
+
+## Checklist
+
+- [ ] My change is focused (one example, one doc page, one fix)
+- [ ] I matched the surrounding tone and formatting
+- [ ] I'm not committing API keys, model weights, or other secrets

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing
+
+Thanks for taking the time to look at this. A quick orientation before you file an issue or open a PR.
+
+## What this repo is
+
+This is the **public binary distribution** of `bitHumanKit`. The Swift source for the framework itself is private. What ships here:
+
+- `Package.swift` — a SwiftPM `binaryTarget` pointing at the `bitHumanKit.xcframework.zip` attached to each [GitHub Release](https://github.com/bithuman-product/bithuman-sdk-public/releases).
+- `Examples/` — annotated sample apps and integration recipes.
+- `docs/` — the source for [docs.bithuman.ai](https://docs.bithuman.ai) (Mintlify).
+- `python/` — packaging metadata for the Python wheel publish.
+
+Because the SDK source is closed, **most "the SDK does X wrong" reports cannot be fixed by a PR to this repo.** Read on for where to send what.
+
+## Where to send issues
+
+### File an issue here when…
+
+- The `binaryTarget` checksum, URL, or version range in `Package.swift` is broken.
+- A release artifact (the `.xcframework.zip`) is missing, corrupted, or won't notarize.
+- Documentation under `docs/` is wrong, stale, or unclear.
+- An example under `Examples/` doesn't build or behaves unexpectedly.
+- The Python wheel (`python/`) packaging is broken.
+
+For these, please use [Bug report](.github/ISSUE_TEMPLATE/bug_report.md) and include the SDK version, OS, Xcode version, and a minimal repro.
+
+### Don't file an issue here for…
+
+- **SDK runtime behavior** (lipsync drift, audio glitches, model loading, hardware gating, API design). The implementation is private. Please email **support@bithuman.ai** or post in our [community forum](https://www.bithuman.ai/community) instead — your report still reaches the engineers, just through the right channel.
+- **API key, billing, or credit issues** — email **support@bithuman.ai**.
+- **Security vulnerabilities** — see [SECURITY.md](SECURITY.md). Please don't open a public issue.
+
+## PRs we welcome
+
+Pull requests are welcome for:
+
+- `Examples/` — new sample apps, fixes to existing ones, integration recipes.
+- `docs/` — typo fixes, clarifications, new guides, better diagrams.
+- `README.md` and other repo metadata.
+
+PRs that try to modify `Package.swift` versions or release artifacts will usually be closed — those are bumped by our release automation when a new framework build ships. If you think the package manifest itself has a real bug, open an issue first and we'll talk through it.
+
+## Working on examples or docs
+
+```sh
+git clone https://github.com/bithuman-product/bithuman-sdk-public.git
+cd bithuman-sdk-public
+
+# Examples
+cd Examples/<example-you-want> && open Package.swift
+
+# Docs (Mintlify)
+cd docs && npx mintlify dev
+```
+
+Keep changes focused — one example or one doc page per PR is easiest to review. Match the surrounding tone (the docs lean conversational, not corporate). If you're adding a new example, please include a short `README.md` in its directory explaining what it demonstrates and what hardware it needs.
+
+## Code of conduct
+
+Be kind. Assume good intent. We'll do the same.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you think you've found a security issue in `bitHumanKit` or any of the artifacts published from this repo, **please don't file a public GitHub issue**. Public reports give attackers a head start before we can ship a fix.
+
+Email **security@bithuman.ai** with:
+
+- A description of the issue and what an attacker could do with it.
+- Steps to reproduce, ideally with a minimal sample project.
+- The SDK version (`Package.resolved` entry or release tag) and the OS / Xcode version where you saw it.
+- Your name or handle if you'd like credit in the advisory.
+
+## What to expect
+
+- We aim to acknowledge every report **within 48 hours** (usually much sooner during the work week).
+- We'll keep you posted as we triage, reproduce, and fix.
+- Once a fix ships, we'll publish a GitHub Security Advisory crediting you (unless you'd rather stay anonymous) and CVE if applicable.
+- We support **coordinated disclosure** — we'll agree on a public disclosure date with you before we publish.
+
+## Scope
+
+In scope:
+
+- The `bitHumanKit.xcframework` binaries attached to [Releases](https://github.com/bithuman-product/bithuman-sdk-public/releases).
+- The published Python wheel.
+- Examples and snippets in this repo.
+- `docs.bithuman.ai` content served from `docs/`.
+
+Out of scope (please report to **support@bithuman.ai** instead):
+
+- Issues in third-party dependencies that are statically linked into the framework (we'll forward upstream where appropriate).
+- Social-engineering or physical-access attacks against bitHuman staff or infrastructure.
+- Findings that require a jailbroken device or disabled OS protections.
+
+## PGP / encrypted reports
+
+If you'd like to encrypt your report, email security@bithuman.ai first and we'll exchange a key. We don't publish a static PGP key on the repo because keys rotate.
+
+Thanks for helping keep bitHuman users safe.


### PR DESCRIPTION
## Summary

Adds standard open-source contribution metadata to this repo. Content is tailored to its role as the public **binary distribution** of `bitHumanKit` (SDK source is private).

## Files added

- `CONTRIBUTING.md` — orients contributors: what kinds of issues belong here (binaryTarget bugs, doc fixes, broken examples, Python wheel packaging) vs. what should go to `support@bithuman.ai` (runtime SDK behavior, since the source is closed). PRs welcomed for `Examples/` and `docs/`.
- `SECURITY.md` — vuln-disclosure path via `security@bithuman.ai`, 48h ack target, coordinated disclosure, scope/out-of-scope.
- `.github/ISSUE_TEMPLATE/bug_report.md` — repo-scoped (Package.swift / examples / docs / wheel) with a callout that runtime SDK bugs go elsewhere.
- `.github/ISSUE_TEMPLATE/feature_request.md` — same scoping; SDK API requests redirected.
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues, surfaces support@/docs/security links right on the New Issue page.
- `.github/PULL_REQUEST_TEMPLATE.md` — checklist: area, test notes, no-secrets reminder, warning that version bumps are owned by release automation.

## Why this fits this repo

This repo's pain point is that users land here from `Package.swift` and report runtime SDK bugs that nobody here can fix. The templates surface that early so reports route to engineers faster.

## Test plan

- [ ] CONTRIBUTING.md and SECURITY.md render correctly on GitHub
- [ ] "New issue" page shows Bug report + Feature request, plus the contact links from config.yml
- [ ] PR template auto-populates when opening a fresh PR

Not merged — leaving for review.

Generated with Claude Code.