### PR TITLE
Examples: polish READMEs after consolidation

### DIFF
--- a/Examples/AGENTS.md
+++ b/Examples/AGENTS.md
@@ -27,7 +27,7 @@ integrations/
   macos-offline/                      Fully offline macOS (Ollama + Apple Speech)
   nextjs-ui/                          Drop-in Next.js LiveKit frontend
   web-ui/                             Gradio + FastRTC browser UI
-bithuman-docs/                        Mintlify source for docs.bithuman.ai
+../docs/                              Mintlify source for docs.bithuman.ai (sibling of Examples/)
 ```
 
 ## Conventions
@@ -39,10 +39,10 @@ bithuman-docs/                        Mintlify source for docs.bithuman.ai
 
 ## Authoritative docs
 
-- Product / API / deployment: [docs.bithuman.ai](https://docs.bithuman.ai) (source in [`bithuman-docs/`](bithuman-docs/))
+- Product / API / deployment: [docs.bithuman.ai](https://docs.bithuman.ai) (source in [`../docs/`](../docs/))
 - Python SDK surface: [pypi.org/project/bithuman](https://pypi.org/project/bithuman/) (the SDK source repo is private; internal links from PyPI point at docs.bithuman.ai)
 - Swift SDK: [github.com/bithuman-product/bithuman-sdk-public](https://github.com/bithuman-product/bithuman-sdk-public) — binary Swift Package (XCFramework). Source is private; the public package wraps the released framework via `binaryTarget`.
-- Swift reference apps (Mac, iPad, iPhone): github.com/bithuman-product/bithuman-apps
+- Swift reference apps (Mac, iPad, iPhone): private repo (`bithuman-apps`). Only compiled binaries ship publicly — see [docs.bithuman.ai/swift-sdk/quickstart](https://docs.bithuman.ai/swift-sdk/quickstart) for the latest download.
 - bithuman-cli (Homebrew): `brew tap bithuman-product/bithuman && brew install bithuman-cli`
 - REST API: [`docs.bithuman.ai/api-reference/openapi.yaml`](https://docs.bithuman.ai/api-reference/openapi.yaml)
 - Compact AI-agent ingest: [`docs.bithuman.ai/llms.txt`](https://docs.bithuman.ai/llms.txt) · Comprehensive: [`docs.bithuman.ai/llms-full.txt`](https://docs.bithuman.ai/llms-full.txt)
@@ -57,7 +57,7 @@ If you are an AI agent (Claude, Cursor, Copilot, etc.) wiring bitHuman into a us
 
 | User says they want… | Recommend | Why |
 |---|---|---|
-| "Mac / iPad / iPhone app, runs locally, privacy" | [Swift SDK quickstart](https://docs.bithuman.ai/swift-sdk/quickstart) → bithuman-sdk-public + a reference app from bithuman-apps | All inference on-device. M3+ Mac / M4+ iPad Pro / iPhone 16 Pro+. |
+| "Mac / iPad / iPhone app, runs locally, privacy" | [Swift SDK quickstart](https://docs.bithuman.ai/swift-sdk/quickstart) → bithuman-sdk-public Swift Package + the prebuilt reference app from the docs | All inference on-device. M3+ Mac / M4+ iPad Pro / iPhone 16 Pro+. The reference app source is private; binaries are linked from the docs. |
 | "No setup, fastest demo on a Mac" | `brew install bithuman-cli` → `bithuman-cli video`. See [/swift-sdk/cli](https://docs.bithuman.ai/swift-sdk/cli). | No code. Voice + avatar window in 30 seconds. |
 | "Web app, fastest cloud demo" | [`essence-cloud/`](essence-cloud/) | LiveKit plugin, no GPU, no model files. |
 | "Web app with custom face from a photo" | [`expression-cloud/`](expression-cloud/) | Same plugin, `model="expression"` + `avatar_image`. |
@@ -83,6 +83,6 @@ If you are an AI agent (Claude, Cursor, Copilot, etc.) wiring bitHuman into a us
 ### What NOT to do
 
 - Don't add `bithuman-kit.git` (private) as an SPM dependency. Use `bithuman-sdk-public.git`.
-- Don't try to clone the source for the Swift SDK — it's intentionally private. Suggest the public binary package or a reference app.
+- Don't try to clone the source for the Swift SDK or the reference apps (`bithuman-apps`) — both are intentionally private. Suggest the public binary package or the prebuilt reference app linked from the docs.
 - Don't hardcode API keys in source. Use env vars; for production Swift apps, fetch from Keychain or bundle into the `.app` Info.plist via a build script (see [authentication docs](https://docs.bithuman.ai/getting-started/authentication)).
 - Don't pin the Swift SDK below 0.8.1 — earlier versions had a different (now-replaced) auth model.

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -29,7 +29,7 @@ Native on-device voice + lip-synced avatar for **Mac, iPad, iPhone**. Ships as a
 | | What |
 |---|---|
 | **[`bithuman-product/bithuman-sdk-public`](https://github.com/bithuman-product/bithuman-sdk-public)** | Public SwiftPM binary package. `import bitHumanKit`. Hardware floor: M3+ Mac / M4+ iPad Pro / iPhone 16 Pro+. |
-| **`bitHuman reference apps (private)`** | Annotated Mac / iPad / iPhone reference apps that consume the SDK. Clone, run one command, get a working avatar. |
+| **`bitHuman reference apps (private)`** | Annotated Mac / iPad / iPhone reference apps that consume the SDK. Source is private; prebuilt binaries are linked from [docs.bithuman.ai/swift-sdk/quickstart](https://docs.bithuman.ai/swift-sdk/quickstart). |
 | **`bithuman-cli`** ([Homebrew tap](https://github.com/bithuman-product/homebrew-bithuman)) | No-code Mac tool. `brew install bithuman-cli` → `bithuman-cli video`. |
 
 Quickstart: [docs.bithuman.ai/swift-sdk/quickstart](https://docs.bithuman.ai/swift-sdk/quickstart).

--- a/Examples/essence-cloud/README.md
+++ b/Examples/essence-cloud/README.md
@@ -15,7 +15,7 @@ No local GPU, no `.imx` model files. Just an API secret and an agent ID.
 ```bash
 # 1. Clone and enter the directory
 git clone https://github.com/bithuman-product/bithuman-sdk-public.git
-cd bithuman-examples/essence-cloud
+cd bithuman-sdk-public/Examples/essence-cloud
 
 # 2. Create your .env file
 cp .env.example .env

--- a/Examples/essence-selfhosted/README.md
+++ b/Examples/essence-selfhosted/README.md
@@ -29,7 +29,7 @@ python generation.py --prompt "You are a friendly assistant" --download --output
 ```bash
 # 1. Clone and enter the directory
 git clone https://github.com/bithuman-product/bithuman-sdk-public.git
-cd bithuman-examples/essence-selfhosted
+cd bithuman-sdk-public/Examples/essence-selfhosted
 
 # 2. Place your .imx model(s)
 mkdir -p models

--- a/Examples/expression-cloud/README.md
+++ b/Examples/expression-cloud/README.md
@@ -15,7 +15,7 @@ No local GPU needed. Provide any face image and the cloud renders a high-fidelit
 ```bash
 # 1. Clone and enter the directory
 git clone https://github.com/bithuman-product/bithuman-sdk-public.git
-cd bithuman-examples/expression-cloud
+cd bithuman-sdk-public/Examples/expression-cloud
 
 # 2. Create your .env file
 cp .env.example .env

--- a/Examples/expression-selfhosted-livekit-cloud/README.md
+++ b/Examples/expression-selfhosted-livekit-cloud/README.md
@@ -16,7 +16,7 @@ Everything else — GPU requirements, image size, startup time, performance, `/h
 
 ```bash
 git clone https://github.com/bithuman-product/bithuman-sdk-public.git
-cd bithuman-examples/expression-selfhosted-livekit-cloud
+cd bithuman-sdk-public/Examples/expression-selfhosted-livekit-cloud
 
 cp .env.example .env
 # Edit .env: set BITHUMAN_API_SECRET, OPENAI_API_KEY, and LiveKit Cloud creds.
@@ -46,6 +46,17 @@ Only these are new vs. `expression-selfhosted`:
 
 All other vars (`BITHUMAN_API_SECRET`, `OPENAI_API_KEY`, `BITHUMAN_AVATAR_IMAGE`, `CUDA_VISIBLE_DEVICES`, `AGENT_PROMPT`, `OPENAI_VOICE`, `GPU_PORT`) work the same as in `../expression-selfhosted/.env.example`.
 
+## Terminal-only quickstart (no LiveKit)
+
+Once the GPU container is running on port 8089, `quickstart.py` drives it directly through the SDK — useful for benchmarking or for piping audio in from your own code without the LiveKit/frontend layers.
+
+```bash
+pip install -r requirements.txt
+python quickstart.py --avatar-image face.jpg --audio-file speech.wav
+```
+
+Press `Q` to quit. Override `--gpu-url` if the container is on another host or port.
+
 ## Troubleshooting specific to this variant
 
 **Agent can't connect to LiveKit Cloud?**
@@ -60,6 +71,9 @@ For GPU/image/model issues, see the [expression-selfhosted troubleshooting](../e
 | File | Description |
 |------|-------------|
 | `docker-compose.yml` | 3-service stack (GPU + agent + frontend) |
+| `agent.py` | LiveKit agent that dispatches to the local GPU container |
+| `quickstart.py` | Terminal-only demo — drives the GPU container directly via the SDK |
 | `.env.example` | Env template including LiveKit Cloud vars |
+| `speech.wav` | Sample audio bundled for testing |
 
-For a terminal-only demo without LiveKit, hit the GPU container's HTTP API directly — see [`../expression-selfhosted/README.md`](../expression-selfhosted/README.md#curl-demo).
+For a curl-only path that hits the GPU container's HTTP API without Python, see [Quick Start (GPU Container Only)](../expression-selfhosted/README.md#quick-start-gpu-container-only) in the sibling example.

--- a/Examples/expression-selfhosted/README.md
+++ b/Examples/expression-selfhosted/README.md
@@ -28,7 +28,7 @@ If this fails, install the [NVIDIA Container Toolkit](https://docs.nvidia.com/da
 ```bash
 # 1. Clone and enter the directory
 git clone https://github.com/bithuman-product/bithuman-sdk-public.git
-cd bithuman-examples/expression-selfhosted
+cd bithuman-sdk-public/Examples/expression-selfhosted
 
 # 2. Create your .env file
 cp .env.example .env

--- a/Examples/integrations/nextjs-ui/CONTRIBUTING.md
+++ b/Examples/integrations/nextjs-ui/CONTRIBUTING.md
@@ -28,7 +28,7 @@ If you find a bug or have a suggestion for improvement:
 ```bash
 # Clone your fork
 git clone https://github.com/bithuman-product/bithuman-sdk-public.git
-cd bithuman-livekit-ui-example
+cd bithuman-sdk-public/Examples/integrations/nextjs-ui
 
 # Install dependencies
 npm install

--- a/Examples/integrations/nextjs-ui/README.md
+++ b/Examples/integrations/nextjs-ui/README.md
@@ -37,7 +37,7 @@ A modern, responsive web interface for connecting to bitHuman's AI agents via Li
 1. **Clone the repository**
    ```bash
    git clone https://github.com/bithuman-product/bithuman-sdk-public.git
-   cd integrations/nextjs-ui
+   cd bithuman-sdk-public/Examples/integrations/nextjs-ui
    ```
 
 2. **Install dependencies**


### PR DESCRIPTION
## Summary

Audit pass over `Examples/` after the 2026-05 consolidation. Most examples were already in good shape from earlier sweeps — this batch fixes the leftover references to the archived `bithuman-examples` repo layout, a broken anchor, and the AGENTS.md guidance that still pointed at `bithuman-docs/` and treated `bithuman-apps` as a public repo.

## Per-example status

| Example | Status | Changes applied |
|---|---|---|
| `Examples/README.md` (top-level) | minor fix | Updated reference-apps row to clarify source is private and link the docs page for binaries |
| `Examples/AGENTS.md` | minor fix | `bithuman-docs/` → `../docs/`; reframed `bithuman-apps` as a private repo with public binaries; tightened the "What NOT to do" guidance |
| `api/` | clean | No changes needed |
| `apple-expression/` | clean | No changes needed |
| `essence-cloud/` | minor fix | Quick-start `cd bithuman-examples/...` → `cd bithuman-sdk-public/Examples/...` |
| `essence-selfhosted/` | minor fix | Same `cd` path fix |
| `expression-cloud/` | minor fix | Same `cd` path fix |
| `expression-selfhosted/` | minor fix | Same `cd` path fix |
| `expression-selfhosted-livekit-cloud/` | needs touch-up | Same `cd` path fix; broken `#curl-demo` anchor → `#quick-start-gpu-container-only`; surfaced existing `quickstart.py` / `agent.py` / `speech.wav` in the Files table; added a short "Terminal-only quickstart" section |
| `integrations/java/` | clean | No changes needed |
| `integrations/macos-offline/` | clean | No changes needed (see flagged item below) |
| `integrations/nextjs-ui/` | minor fix | README + CONTRIBUTING `cd` paths fixed |
| `integrations/web-ui/` | clean | No changes needed |

## Flagged for human review (no edits applied)

- **`integrations/java/bithuman_streaming_server.py` + Java README** still expose `BITHUMAN_RUNTIME_TOKEN` as a CLI/env option. AGENTS.md flags this as the legacy auth path. The flag is harmless but could be removed in a follow-up if we want to retire it across the SDK examples.
- **`integrations/macos-offline/`** — references a private `bithuman-voice` wheel ("Preview — private distribution"). README is honest about this; flagging as user-facing friction. Also: the example ships an `assets/` directory of screenshots that the README never references — could be wired into a "Screenshots" section in a follow-up, but didn't want to expand README scope here.
- **`integrations/macos-offline/`** has no `.env.example`; instead the README inlines the env vars. Inconsistent with the rest of the repo but works fine.
- **`integrations/nextjs-ui/package.json`** still has `"name": "bithuman-livekit-ui-example"`. Cosmetic; left untouched per the "don't edit code unless obviously correct" guideline.

## Test plan

- [ ] Spot-check the five updated `cd` quick-start blocks against a fresh `git clone` of this repo
- [ ] Click the updated `#quick-start-gpu-container-only` anchor in the rendered `expression-selfhosted-livekit-cloud/README.md` on GitHub
- [ ] Verify the Examples/README.md reference-apps row reads cleanly given the docs link

🤖 Generated with [Claude Code](https://claude.com/claude-code)