### PR TITLE
docs: clarify python/ and swift/ are landing pages, not source dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,17 @@ Don't have an `.imx` file? Download one from [bithuman.ai → Explore](https://w
 ## What's in this repo
 
 ```
-├── python/                    Python SDK documentation and changelog
-├── swift/                     Swift SDK documentation and changelog
-├── Package.swift              Swift package manifest (required at root by SwiftPM)
+├── Package.swift              Swift package manifest — the binary distribution of bitHumanKit
+│                              (binaryTarget consuming bitHumanKit.xcframework.zip from
+│                              this repo's GitHub Releases). Required at root by SwiftPM.
+│
+├── python/                    Per-language landing page for the `bithuman` PyPI package.
+│                              README, CHANGELOG, LICENSE — no SDK source (the runtime
+│                              ships as wheels, source is private).
+├── swift/                     Per-language landing page for the `bitHumanKit` Swift package.
+│                              README, CHANGELOG, LICENSE — no SDK source (the framework
+│                              ships as a pre-compiled xcframework consumed via Package.swift
+│                              above).
 │
 ├── Examples/                  Working code you can run
 │   ├── quickstart/                Your first demo (start here)
@@ -129,10 +137,12 @@ Don't have an `.imx` file? Download one from [bithuman.ai → Explore](https://w
 │   ├── rest-api/                  curl and Python scripts for the HTTP API
 │   └── integrations/              Next.js, Java, Gradio, offline Mac
 │
-├── docs/                      Source for docs.bithuman.ai
+├── docs/                      Source for docs.bithuman.ai (Mintlify)
 ├── AGENTS.md                  Instructions for AI coding agents
 └── CONTRIBUTING.md            How to contribute to this repo
 ```
+
+> **Heads up on `python/` and `swift/`.** These directories hold the per-language landing pages and changelogs only — the SDK runtime sources are private (signing material is baked into the published artefacts). Use them as a navigation entry point ("here is the README and version history for the Python SDK") rather than expecting to find source. To install: `pip install bithuman` (Python) or add the SwiftPM URL above (Swift). To file a bug: [bithuman-sdk-public/issues](https://github.com/bithuman-product/bithuman-sdk-public/issues).
 
 ## Pricing
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,4 +1,6 @@
-# bitHuman Avatar Runtime
+# bitHuman Avatar Runtime — Python SDK landing page
+
+> **What this directory is.** The per-language landing page (README + [CHANGELOG](CHANGELOG.md) + [LICENSE](LICENSE.md)) for the [`bithuman` package on PyPI](https://pypi.org/project/bithuman/). **The SDK runtime source is private** — signing material is baked into the published wheels. To install: `pip install bithuman`. To browse runnable examples: [`Examples/python/`](../Examples/python/). To file a bug or request a feature: [bithuman-sdk-public/issues](https://github.com/bithuman-product/bithuman-sdk-public/issues).
 
 ![bitHuman Banner](https://docs.bithuman.ai/images/bithuman-banner.jpg)
 

--- a/swift/README.md
+++ b/swift/README.md
@@ -1,4 +1,6 @@
-# bitHumanKit — Swift SDK
+# bitHumanKit — Swift SDK landing page
+
+> **What this directory is.** The per-language landing page (README + [CHANGELOG](CHANGELOG.md) + [LICENSE](LICENSE.md)) for the `bitHumanKit` Swift package. **The SDK source is private** — the framework ships as a pre-compiled `bitHumanKit.xcframework` consumed via the `Package.swift` at this repo's root (a SwiftPM `binaryTarget` pointing at the latest GitHub Release). To install: add the SwiftPM URL `https://github.com/bithuman-product/bithuman-sdk-public.git` to your Xcode project. To browse runnable examples: [`Examples/swift/`](../Examples/swift/). To file a bug: [bithuman-sdk-public/issues](https://github.com/bithuman-product/bithuman-sdk-public/issues).
 
 ![bitHuman Banner](https://docs.bithuman.ai/images/bithuman-banner.jpg)
 


### PR DESCRIPTION
## Summary

The `python/` and `swift/` directories at this repo's root hold per-language landing pages (README + CHANGELOG + LICENSE) for the SDKs distributed via PyPI (`bithuman`) and SwiftPM (`bitHumanKit`). The runtime source is private. A new visitor browsing here sees `python/` and reasonably expects Python source — the previous top-level description ("Python SDK documentation and changelog") was technically accurate but didn't flag the source-is-elsewhere expectation.

## What changed

- Top-level README "What's in this repo" describes both dirs more explicitly and adds a "Heads up" callout.
- `python/README.md` and `swift/README.md` each gain a one-paragraph blockquote at the very top with the same clarification inline. So a PyPI "Source" deep-link or anyone navigating directly to `/python` sees it immediately, not just at the org-level entry point.

## Why not rename to `python-changelog/` / `swift-changelog/`

I originally proposed a rename in the audit. On closer inspection these directories aren't just changelog stubs — `python/README.md` is a substantial install/usage page and `swift/README.md` is similarly content-rich. They're the equivalent of per-SDK landing pages.

A rename would also force breaking changes:
- Every previously published `bithuman` wheel on PyPI links its "Source" / "Changelog" URLs at `bithuman-sdk-public/tree/main/python` (and `/blob/main/python/CHANGELOG.md`). Already-installed wheels would 404.
- `docs/changelog.mdx` and `docs/getting-started/quickstart.mdx` link at `python/CHANGELOG.md`.

The upside (slightly more obvious naming) does not justify the breakage. Inline clarification accomplishes the same comprehension goal with zero migration cost.

## Test plan

- [x] No code change, no link rewrite — only README copy
- [x] Verified `git diff --stat` is small (20 insertions, 6 deletions across 3 files)
- [ ] Render check on the rendered README in this PR's preview