### PR TITLE
fix(examples): update dockerfiles to clone bithuman-sdk-public

### DIFF
--- a/Examples/integrations/offline-mac/webui.dockerfile
+++ b/Examples/integrations/offline-mac/webui.dockerfile
@@ -6,8 +6,8 @@ WORKDIR /app
 RUN apk add --no-cache git
 
 # Clone the LiveKit agents playground frontend
-RUN git clone --depth 1 https://github.com/bithuman-product/examples.git /tmp/repo && \
-    cp -r /tmp/repo/integrations/nextjs-ui/. . && \
+RUN git clone --depth 1 https://github.com/bithuman-product/bithuman-sdk-public.git /tmp/repo && \
+    cp -r /tmp/repo/Examples/integrations/nextjs-ui/. . && \
     rm -rf /tmp/repo
 
 # Install dependencies

--- a/Examples/python/cloud-essence/webui.dockerfile
+++ b/Examples/python/cloud-essence/webui.dockerfile
@@ -4,8 +4,8 @@ WORKDIR /app
 
 RUN apk add --no-cache git
 
-RUN git clone --depth 1 https://github.com/bithuman-product/examples.git /tmp/repo && \
-    cp -r /tmp/repo/integrations/nextjs-ui/. . && \
+RUN git clone --depth 1 https://github.com/bithuman-product/bithuman-sdk-public.git /tmp/repo && \
+    cp -r /tmp/repo/Examples/integrations/nextjs-ui/. . && \
     rm -rf /tmp/repo
 
 RUN npm cache clean --force && \

--- a/Examples/python/cloud-expression/webui.dockerfile
+++ b/Examples/python/cloud-expression/webui.dockerfile
@@ -4,8 +4,8 @@ WORKDIR /app
 
 RUN apk add --no-cache git
 
-RUN git clone --depth 1 https://github.com/bithuman-product/examples.git /tmp/repo && \
-    cp -r /tmp/repo/integrations/nextjs-ui/. . && \
+RUN git clone --depth 1 https://github.com/bithuman-product/bithuman-sdk-public.git /tmp/repo && \
+    cp -r /tmp/repo/Examples/integrations/nextjs-ui/. . && \
     rm -rf /tmp/repo
 
 RUN npm cache clean --force && \

--- a/Examples/python/local-essence/webui.dockerfile
+++ b/Examples/python/local-essence/webui.dockerfile
@@ -4,8 +4,8 @@ WORKDIR /app
 
 RUN apk add --no-cache git
 
-RUN git clone --depth 1 https://github.com/bithuman-product/examples.git /tmp/repo && \
-    cp -r /tmp/repo/integrations/nextjs-ui/. . && \
+RUN git clone --depth 1 https://github.com/bithuman-product/bithuman-sdk-public.git /tmp/repo && \
+    cp -r /tmp/repo/Examples/integrations/nextjs-ui/. . && \
     rm -rf /tmp/repo
 
 RUN npm cache clean --force && \

--- a/Examples/python/local-expression-gpu/webui.dockerfile
+++ b/Examples/python/local-expression-gpu/webui.dockerfile
@@ -4,8 +4,8 @@ WORKDIR /app
 
 RUN apk add --no-cache git
 
-RUN git clone --depth 1 https://github.com/bithuman-product/examples.git /tmp/repo && \
-    cp -r /tmp/repo/integrations/nextjs-ui/. . && \
+RUN git clone --depth 1 https://github.com/bithuman-product/bithuman-sdk-public.git /tmp/repo && \
+    cp -r /tmp/repo/Examples/integrations/nextjs-ui/. . && \
     rm -rf /tmp/repo
 
 RUN npm cache clean --force && \


### PR DESCRIPTION
## Summary

Five webui dockerfiles in `Examples/` cloned `https://github.com/bithuman-product/examples.git` — a repo that no longer exists post-2026-05-05 consolidation — to copy `integrations/nextjs-ui/` into the build context. After consolidation those examples live inside this repo at `Examples/integrations/nextjs-ui/`. As-is, every one of these dockerfiles fails at `docker build` step 7 with a 404 on `git clone`.

Found by a follow-up sweep after the org-level audit (#6) merged: scanned all `Examples/`, `docs/`, and top-level docs for references to bithuman-product repos and confirmed the only misses were these five dockerfiles.

## What changed

For each of:

- `Examples/integrations/offline-mac/webui.dockerfile`
- `Examples/python/local-expression-gpu/webui.dockerfile`
- `Examples/python/cloud-expression/webui.dockerfile`
- `Examples/python/cloud-essence/webui.dockerfile`
- `Examples/python/local-essence/webui.dockerfile`

Two-line edit:

```diff
- RUN git clone --depth 1 https://github.com/bithuman-product/examples.git /tmp/repo && \
-     cp -r /tmp/repo/integrations/nextjs-ui/. . && \
+ RUN git clone --depth 1 https://github.com/bithuman-product/bithuman-sdk-public.git /tmp/repo && \
+     cp -r /tmp/repo/Examples/integrations/nextjs-ui/. . && \
```

## Test plan

- [x] `Examples/integrations/nextjs-ui/` confirmed to exist in this repo (the `cp -r` source is real)
- [x] All 5 dockerfiles audited — same one-pattern fix applies to each
- [ ] `docker build -f Examples/python/local-essence/webui.dockerfile .` smoke-test from a fresh checkout once merged (no Docker access in the sweep environment)