### PR TITLE
docs(Package.swift): correct source-of-truth pointer in header comment

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,13 @@
 // swift-tools-version: 6.0
 // bitHumanKit — public binary distribution.
 //
-// The source for bitHumanKit lives in the private repo
-// bithuman-product/bithuman-kit. This package consumes the
-// pre-compiled XCFramework attached to that repo's GitHub
-// Releases via SwiftPM's binaryTarget.
+// The source for bitHumanKit lives in the swift/ tree of the private
+// monorepo bithuman-product/bithuman-sdk (formerly the standalone
+// bithuman-product/bithuman-kit before the 2026-05-05 consolidation).
+// This package consumes the pre-compiled XCFramework attached to
+// THIS repo's GitHub Releases via SwiftPM's binaryTarget — the
+// `.xcframework.zip` is built from bithuman-sdk and uploaded here
+// per release; consumers depend only on this package URL.
 //
 // All third-party deps (MLX, HuggingFace, Tokenizers, …) are
 // statically linked into the framework binary, so consumers


### PR DESCRIPTION
## Summary

The header comment of `Package.swift` said:
> The source for bitHumanKit lives in the private repo bithuman-product/bithuman-kit.

That was true pre-consolidation. Today the Swift source lives in the `swift/` tree of `bithuman-product/bithuman-sdk` (the monorepo); the xcframework attached to this repo's Releases is built from there.

This is the most-read manifest in the public SDK distribution — every external dev sees it when they "View Package.swift" or inspect the dependency in Xcode's Package Dependencies pane.

## Diff

```diff
-// The source for bitHumanKit lives in the private repo
-// bithuman-product/bithuman-kit. This package consumes the
-// pre-compiled XCFramework attached to that repo's GitHub
-// Releases via SwiftPM's binaryTarget.
+// The source for bitHumanKit lives in the swift/ tree of the private
+// monorepo bithuman-product/bithuman-sdk (formerly the standalone
+// bithuman-product/bithuman-kit before the 2026-05-05 consolidation).
+// This package consumes the pre-compiled XCFramework attached to
+// THIS repo's GitHub Releases via SwiftPM's binaryTarget — the
+// `.xcframework.zip` is built from bithuman-sdk and uploaded here
+// per release; consumers depend only on this package URL.
```

## Test plan

- [x] No code change; comment-only edit
- [x] `binaryTarget` URL + checksum unchanged
- [x] Header still parses (Swift comments)
- [x] Found by fresh-eye audit after PR #6 merged