### PR TITLE
docs: accuracy audit + Examples redesign

### DIFF
--- a/Examples/cli/README.md
+++ b/Examples/cli/README.md
@@ -1,99 +1,116 @@
 # bitHuman CLI Tools
 
-Command-line tools for rendering video, streaming avatars, and running the bitHuman desktop app.
+Command-line tools for rendering video, streaming an avatar, and
+running voice / text / browser-avatar conversations — no code.
 
-## Setup
+## Install
 
-All CLI tools require a bitHuman API secret. Get yours at [www.bithuman.ai/#developer](https://www.bithuman.ai/#developer).
+The `bithuman` command is a single self-contained binary, installed via
+Homebrew or the universal one-liner. It is **not** the `pip install
+bithuman` package (that ships the Python *SDK* plus an `essence-render`
+console script — see the [Python examples](../python/)).
+
+```bash
+# macOS — Homebrew (recommended; pulls native deps).
+brew install bithuman-product/bithuman/bithuman
+
+# macOS / Linux — universal one-liner.
+curl -fsSL https://github.com/bithuman-product/homebrew-bithuman/releases/latest/download/install.sh | sh
+```
+
+All commands need a bitHuman API secret. Get yours at
+[www.bithuman.ai/#developer](https://www.bithuman.ai/#developer).
 
 ```bash
 export BITHUMAN_API_SECRET="your_secret_here"
+bithuman doctor      # verify host setup + API key presence
 ```
 
 ---
 
-## 1. `bithuman` CLI (Python SDK)
-
-Installed via pip. Works on Linux, macOS, and Windows.
-
-```bash
-pip install bithuman
-```
-
-### Commands
+## Commands
 
 | Command | Description |
 |---------|-------------|
-| `bithuman generate <model.imx> --audio speech.wav --output demo.mp4` | Render a lip-synced MP4 from an .imx model and audio file |
-| `bithuman stream <model.imx> --port 8765` | Start a WebSocket streaming server for real-time lip sync |
-| `bithuman speak <audio.wav>` | Send audio to a running `stream` server |
-| `bithuman demo [--model <imx>] [--audio <file>]` | Launch an interactive demo (auto-downloads model if omitted) |
-| `bithuman convert <input> --output <output.imx>` | Convert legacy TAR .imx to v2 format (smaller, faster) |
-| `bithuman pack ...` | Pack Expression weights into an .imx bundle (model authors only) |
-| `bithuman validate` | Validate your API credentials |
-| `bithuman info <model.imx>` | Show metadata for an .imx model file |
-| `bithuman --help` | Full list of all commands and flags |
+| `bithuman doctor` | Host capability check (arch, OS, RAM, disk, API key) |
+| `bithuman generate <model.imx> --audio speech.wav --output demo.mp4` | Offline batch render an MP4 from a model + WAV |
+| `bithuman avatar [--model <imx>]` | Browser-served avatar at `http://127.0.0.1:8080` |
+| `bithuman voice` | Interactive voice chat (auto-picks cloud or `--local`) |
+| `bithuman text` | Non-interactive text chat (stdin → stdout) |
+| `bithuman stream [--model <imx>] [--port 3001]` | HTTP streaming avatar server |
+| `bithuman speak <audio.wav> [--port 3001]` | POST a WAV to a running `stream` server |
+| `bithuman action <name> [--port 3001]` | POST an action trigger (e.g. `wave`) to a `stream` server |
+| `bithuman info <model.imx>` | Show metadata for an `.imx` model file |
+| `bithuman asr <audio.wav>` | Transcribe a 16 kHz mono WAV (on-device Whisper) |
+| `bithuman tts "<text>"` | Synthesize text to a 24 kHz mono WAV (offline) |
+| `bithuman models list` / `pull` | Browse and download showcase avatars |
+| `bithuman cleanup` | Wipe regenerable model caches under `~/.cache` |
+| `bithuman --help` | Full list of commands and flags |
 
-> **Note:** `bithuman demo` with no arguments auto-downloads a demo model (~3.7 GB, cached) on first run. Great for a zero-setup hello world: `pip install bithuman && bithuman demo`.
+Run `bithuman <command> --help` for the full flag list of any command.
 
-### Examples
-
-**Render a video** -- see [render-video.sh](render-video.sh):
+### Render a video — see [render-video.sh](render-video.sh)
 
 ```bash
 bithuman generate model.imx --audio speech.wav --output demo.mp4
 ```
 
-**Start a streaming server** -- see [live-stream.sh](live-stream.sh):
+### Start a streaming server — see [live-stream.sh](live-stream.sh)
 
 ```bash
-bithuman stream model.imx --port 8765
+bithuman stream --model model.imx --port 3001
 
-# Clients connect via WebSocket at ws://127.0.0.1:8765
-# Send audio frames, receive lip-synced video frames at 25 FPS
+# HTTP endpoints (no WebSocket):
+#   POST /audio       raw f32 PCM      GET  /video.mjpg   MJPEG video
+#   POST /action      action trigger   GET  /status       server status
+# Drive it from another shell:  bithuman speak clip.wav --port 3001
 ```
 
-**Quick validation:**
+### Validate your API secret
+
+There is no `bithuman validate` subcommand — use the REST endpoint:
 
 ```bash
-bithuman validate
+curl -s -X POST https://api.bithuman.ai/v1/validate \
+  -H "api-secret: $BITHUMAN_API_SECRET" | python3 -m json.tool
 ```
 
 ---
 
-## 2. `bithuman-cli` (macOS Desktop App)
+## Voice / text / browser-avatar conversations
 
-A native Mac application for interactive voice, text, and video conversations with bitHuman avatars. Runs locally on Apple Silicon.
-
-### Install via Homebrew
-
-```bash
-brew install bithuman-product/bithuman/bithuman
-```
-
-### Requirements
-
-- macOS with Apple Silicon M3 or later (M3, M3 Pro/Max, M4, M4 Pro/Max)
-- Homebrew ([brew.sh](https://brew.sh))
-
-### Modes
+The same `bithuman` binary runs full conversations locally — no agent
+ID, no separate app. Models are `.imx` files, not agent IDs.
 
 | Mode | Command | What it does |
 |------|---------|-------------|
-| Voice | `bithuman-cli --agent-id AXXXXXXXXX --mode voice` | Speak into your microphone, avatar responds in real time |
-| Text | `bithuman-cli --agent-id AXXXXXXXXX --mode text` | Type messages, avatar speaks them aloud |
-| Video | `bithuman-cli --agent-id AXXXXXXXXX --mode video` | Webcam + microphone for face-to-face conversation |
+| Voice | `bithuman voice` | Speak into your mic; spoken reply, with transcript |
+| Text | `bithuman text` | Type messages; the model replies as text |
+| Browser avatar | `bithuman avatar` | Lip-synced avatar in your browser at `127.0.0.1:8080` |
+| Server-side voice + avatar | `bithuman avatar --openai` | Mic + speakers locally, avatar in the browser |
 
-See [mac-app.sh](mac-app.sh) for a wrapper script that handles installation and mode selection.
+`voice` and `text` auto-pick the **cloud** backend when
+`OPENAI_API_KEY` is set (instant, no downloads) or fully **on-device**
+with `--local` (≈5 GB first-run download, then offline). See
+[mac-app.sh](mac-app.sh) for a thin wrapper.
+
+```bash
+export OPENAI_API_KEY=sk-...   # optional — enables the instant cloud path
+bithuman voice                 # or:  bithuman voice --local
+```
+
+Requirements for the on-device modes: macOS Apple Silicon M3+ or
+Linux x86_64 / aarch64.
 
 ---
 
-## 3. REST API via curl
+## REST API via curl
 
-For quick API calls from the terminal without Python, see the [rest-api.sh](rest-api.sh) quickstart or the full curl examples in [../rest-api/curl/](../rest-api/curl/).
+For API calls from the terminal without Python, see
+[rest-api.sh](rest-api.sh) or the full curl examples in
+[../rest-api/curl/](../rest-api/curl/).
 
 ```bash
-# Validate credentials
 curl -s -X POST https://api.bithuman.ai/v1/validate \
   -H "Content-Type: application/json" \
   -H "api-secret: $BITHUMAN_API_SECRET" | python3 -m json.tool
@@ -105,9 +122,9 @@ curl -s -X POST https://api.bithuman.ai/v1/validate \
 
 | Script | Description |
 |--------|-------------|
-| [render-video.sh](render-video.sh) | Render a lip-synced MP4 from .imx + audio using `bithuman generate` |
-| [live-stream.sh](live-stream.sh) | Start a local WebSocket streaming server using `bithuman stream` |
-| [mac-app.sh](mac-app.sh) | Install and run the bithuman-cli desktop app (macOS M3+) |
+| [render-video.sh](render-video.sh) | Render a lip-synced MP4 from `.imx` + audio using `bithuman generate` |
+| [live-stream.sh](live-stream.sh) | Start a local HTTP/MJPEG streaming server using `bithuman stream` |
+| [mac-app.sh](mac-app.sh) | Wrapper for `bithuman voice` / `text` / `avatar` conversations |
 | [rest-api.sh](rest-api.sh) | Quickstart: validate API key + make an agent speak via curl |
 
 ## Environment Variables
@@ -115,10 +132,10 @@ curl -s -X POST https://api.bithuman.ai/v1/validate \
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `BITHUMAN_API_SECRET` | Yes | Your API secret from [www.bithuman.ai/#developer](https://www.bithuman.ai/#developer) |
-| `BITHUMAN_AGENT_ID` | No | Default agent ID for scripts that need one |
+| `OPENAI_API_KEY` | No | Enables the instant cloud backend for `voice` / `text` |
 
 ## Documentation
 
-- [Python SDK on PyPI](https://pypi.org/project/bithuman/)
+- [CLI reference](https://docs.bithuman.ai/getting-started/cli)
 - [REST API reference](https://docs.bithuman.ai/api-reference/overview)
 - [Full documentation](https://docs.bithuman.ai)

--- a/Examples/cli/live-stream.sh
+++ b/Examples/cli/live-stream.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # Start a local bitHuman streaming server.
 #
-# This launches a WebSocket server that streams lip-synced video frames
-# from an .imx model in real time. Clients connect over WebSocket and
-# push audio; the server responds with animated video frames at 25 FPS.
+# This launches an HTTP server that streams lip-synced video frames
+# from an .imx model in real time. Clients POST audio to /audio and
+# read the MJPEG stream from /video.mjpg at 25 FPS. (No WebSocket.)
 #
 # Prerequisites:
-#   pip install bithuman
+#   brew install bithuman-product/bithuman/bithuman   # or the curl one-liner
 #   export BITHUMAN_API_SECRET=your_secret
 #
 # Usage:
@@ -20,8 +20,8 @@ export BITHUMAN_API_SECRET="${BITHUMAN_API_SECRET:?Set BITHUMAN_API_SECRET first
 MODEL="${1:?Usage: ./live-stream.sh <model.imx> [--port PORT] [--host HOST]}"
 shift
 
-# Default port and host
-PORT=8765
+# Defaults match the CLI (`bithuman stream`).
+PORT=3001
 HOST="127.0.0.1"
 
 # Parse optional flags
@@ -33,17 +33,18 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Install the SDK if not already installed
-pip install -q bithuman
-
 echo "Starting bitHuman streaming server"
 echo "  Model:  $MODEL"
-echo "  Server: ws://$HOST:$PORT"
+echo "  Server: http://$HOST:$PORT"
 echo ""
-echo "Connect a WebSocket client to ws://$HOST:$PORT to send audio and"
-echo "receive lip-synced video frames in real time."
+echo "Endpoints:"
+echo "  POST http://$HOST:$PORT/audio        raw f32 PCM in"
+echo "  GET  http://$HOST:$PORT/video.mjpg   lip-synced MJPEG out (25 FPS)"
+echo "  POST http://$HOST:$PORT/action       action trigger"
+echo "  GET  http://$HOST:$PORT/status       server status"
 echo ""
+echo "Drive it from another shell:  bithuman speak clip.wav --port $PORT"
 echo "Press Ctrl+C to stop."
 echo ""
 
-bithuman stream "$MODEL" --port "$PORT" --host "$HOST"
+bithuman stream --model "$MODEL" --port "$PORT" --host "$HOST"

--- a/Examples/cli/mac-app.sh
+++ b/Examples/cli/mac-app.sh
@@ -1,78 +1,85 @@
 #!/usr/bin/env bash
-# Install and run the bitHuman desktop app on macOS via Homebrew.
+# Install and run bitHuman conversation modes via the `bithuman` CLI.
 #
-# bithuman-cli is a native Mac application that runs an AI avatar with
-# voice conversation, text chat, or video input -- all locally on
-# Apple Silicon (M3 or later).
+# The `bithuman` binary runs voice / text / browser-avatar
+# conversations locally on Apple Silicon (M3 or later) — no agent ID,
+# no separate desktop app. Conversations are driven by `.imx` models.
 #
 # Prerequisites:
-#   - macOS with Apple Silicon M3+ (M3, M3 Pro/Max, M4, M4 Pro/Max)
-#   - Homebrew (https://brew.sh)
+#   - macOS with Apple Silicon M3+ (or Linux x86_64 / aarch64)
+#   - Homebrew (https://brew.sh) for the install step
 #   - A bitHuman API secret (https://www.bithuman.ai/#developer)
 #
 # Usage:
-#   ./mac-app.sh install        Install bithuman-cli via Homebrew
-#   ./mac-app.sh voice           Voice conversation mode (microphone)
-#   ./mac-app.sh text            Text chat mode (type messages)
-#   ./mac-app.sh video           Video chat mode (webcam)
+#   ./mac-app.sh install                 Install the bithuman CLI via Homebrew
+#   ./mac-app.sh voice                   Voice conversation (microphone)
+#   ./mac-app.sh text                    Text chat (type messages)
+#   ./mac-app.sh avatar [model.imx]      Browser-served lip-synced avatar
 set -euo pipefail
-
-export BITHUMAN_API_SECRET="${BITHUMAN_API_SECRET:?Set BITHUMAN_API_SECRET first (get yours at https://www.bithuman.ai/#developer)}"
 
 ACTION="${1:-help}"
 
+if [[ "$ACTION" != "install" && "$ACTION" != "help" && "$ACTION" != "--help" && "$ACTION" != "-h" ]]; then
+  export BITHUMAN_API_SECRET="${BITHUMAN_API_SECRET:?Set BITHUMAN_API_SECRET first (get yours at https://www.bithuman.ai/#developer)}"
+fi
+
+# Optional second arg: a model .imx path for `avatar`. If omitted, the
+# CLI uses the bundled sample avatar. `voice`/`text` need no model.
+MODEL_ARG=()
+if [[ -n "${2:-}" ]]; then
+  MODEL_ARG=(--model "$2")
+fi
+
 case "$ACTION" in
   install)
-    echo "Installing bithuman-cli via Homebrew..."
+    echo "Installing the bithuman CLI via Homebrew..."
     echo ""
     brew install bithuman-product/bithuman/bithuman
     echo ""
-    echo "Done. Run: bithuman-cli --help"
+    echo "Done. Run: bithuman doctor"
     ;;
 
   voice)
-    AGENT_ID="${2:-${BITHUMAN_AGENT_ID:?Provide agent ID as second argument or set BITHUMAN_AGENT_ID}}"
-    echo "Starting voice conversation with agent $AGENT_ID..."
-    echo "Speak into your microphone. The avatar responds in real time."
+    echo "Starting voice conversation."
+    echo "Speak into your microphone; the model replies aloud."
+    echo "Set OPENAI_API_KEY for the instant cloud backend, or add --local."
     echo "Press Ctrl+C to stop."
     echo ""
-    bithuman-cli --agent-id "$AGENT_ID" --mode voice
+    bithuman voice
     ;;
 
   text)
-    AGENT_ID="${2:-${BITHUMAN_AGENT_ID:?Provide agent ID as second argument or set BITHUMAN_AGENT_ID}}"
-    echo "Starting text chat with agent $AGENT_ID..."
-    echo "Type messages and the avatar speaks them aloud."
+    echo "Starting text chat. Type messages; the model replies as text."
+    echo "Set OPENAI_API_KEY for the instant cloud backend, or add --local."
     echo "Press Ctrl+C to stop."
     echo ""
-    bithuman-cli --agent-id "$AGENT_ID" --mode text
+    bithuman text
     ;;
 
-  video)
-    AGENT_ID="${2:-${BITHUMAN_AGENT_ID:?Provide agent ID as second argument or set BITHUMAN_AGENT_ID}}"
-    echo "Starting video chat with agent $AGENT_ID..."
-    echo "Uses your webcam and microphone for face-to-face conversation."
+  avatar)
+    echo "Starting the browser-served avatar at http://127.0.0.1:8080"
+    echo "Open the URL, grant mic permission, and talk."
     echo "Press Ctrl+C to stop."
     echo ""
-    bithuman-cli --agent-id "$AGENT_ID" --mode video
+    bithuman avatar "${MODEL_ARG[@]}"
     ;;
 
   help|--help|-h)
-    echo "bitHuman Desktop App (macOS)"
+    echo "bitHuman CLI conversation modes"
     echo ""
     echo "Usage:"
-    echo "  ./mac-app.sh install              Install bithuman-cli via Homebrew"
-    echo "  ./mac-app.sh voice [AGENT_ID]     Voice conversation (microphone)"
-    echo "  ./mac-app.sh text  [AGENT_ID]     Text chat (type messages)"
-    echo "  ./mac-app.sh video [AGENT_ID]     Video chat (webcam)"
+    echo "  ./mac-app.sh install              Install the bithuman CLI via Homebrew"
+    echo "  ./mac-app.sh voice                Voice conversation (microphone)"
+    echo "  ./mac-app.sh text                 Text chat (type messages)"
+    echo "  ./mac-app.sh avatar [model.imx]   Browser-served lip-synced avatar"
     echo ""
     echo "Environment:"
-    echo "  BITHUMAN_API_SECRET   Your API secret (required)"
-    echo "  BITHUMAN_AGENT_ID     Default agent ID (used if not passed as argument)"
+    echo "  BITHUMAN_API_SECRET   Your API secret (required for avatar mode)"
+    echo "  OPENAI_API_KEY        Optional — enables the instant cloud backend"
     echo ""
     echo "Requirements:"
-    echo "  - macOS with Apple Silicon M3 or later"
-    echo "  - Homebrew (https://brew.sh)"
+    echo "  - macOS Apple Silicon M3+ (or Linux x86_64 / aarch64)"
+    echo "  - Homebrew (https://brew.sh) for the install step"
     ;;
 
   *)

--- a/Examples/python/local-expression-mac/README.md
+++ b/Examples/python/local-expression-mac/README.md
@@ -2,7 +2,8 @@
 
 Render a 25 FPS lip-synced MP4 on-device using the bundled Swift runtime. No LLM, STT, TTS, Docker, or LiveKit — just the SDK.
 
-Full docs: [docs.bithuman.ai/examples/apple-expression](https://docs.bithuman.ai/examples/apple-expression).
+Full docs: [Python SDK](https://docs.bithuman.ai/sdks/python) ·
+[Essence vs Expression](https://docs.bithuman.ai/getting-started/models).
 
 ## Requirements
 
@@ -22,32 +23,34 @@ export BITHUMAN_API_SECRET="your_secret_from_bithuman.ai"
 
 The macOS arm64 wheel ships `bithuman-expression-daemon` (the Swift subprocess the runtime spawns for Expression `.imx` files). Nothing else to install.
 
-## Run — CLI path
+## Run — CLI path (no identity override)
+
+The `bithuman` CLI renders an Expression `.imx` with its baked-in face:
 
 ```bash
-bithuman demo --model expression.imx --audio speech.wav
+bithuman generate expression.imx --audio speech.wav --output demo.mp4
 ```
 
-Outputs `demo.mp4`. `--audio` defaults to a bundled sample clip if omitted. Pass `--identity face.jpg` (or a URL) to override the bundle's baked-in face — encoded once on load (~300 ms) and cached:
+The CLI has no face-override flag. To swap the portrait at load time,
+use the script path below.
 
-```bash
-bithuman demo --model expression.imx --identity alice.jpg --output alice.mp4
-bithuman demo --model expression.imx --identity "https://.../portrait.jpg" --output galaxy.mp4
-```
+## Run — custom script path (face override supported)
 
-See the [agent gallery](https://docs.bithuman.ai/examples/apple-expression#agent-gallery) for ready-made identity URLs.
-
-## Run — custom script path
-
-`quickstart.py` drives the same pipeline through `AsyncBithuman.create()` directly — useful when you're about to swap audio/identity/output for your own data flow.
+`quickstart.py` drives the same pipeline through `AsyncBithuman.create()`
+directly. Its `--identity` argument overrides the bundle's baked-in
+face with any local image path or URL — encoded once on load
+(~300 ms) and cached.
 
 ```bash
 pip install -r requirements.txt
 python quickstart.py --model expression.imx --audio speech.wav --output out.mp4
 python quickstart.py --model expression.imx --audio speech.wav --identity alice.jpg --output alice.mp4
+python quickstart.py --model expression.imx --audio speech.wav --identity "https://.../portrait.jpg" --output galaxy.mp4
 ```
 
-Pre-encoded `.npy` identities load instantly — useful if the same portrait is reused across sessions.
+Browse ready-made faces on [bithuman.ai → Explore](https://www.bithuman.ai/#explore).
+Pre-encoded `.npy` identities load instantly — useful if the same
+portrait is reused across sessions.
 
 ## What this demonstrates
 
@@ -60,4 +63,5 @@ Swap `--audio` for a live mic stream or pair with a TTS for a talking agent — 
 ## Related
 
 - [Python SDK on PyPI](https://pypi.org/project/bithuman/)
-- [bitHuman Halo — consumer macOS app built on this pipeline](https://docs.bithuman.ai/examples/halo-macos)
+- [Python SDK docs](https://docs.bithuman.ai/sdks/python)
+- [macos-avatar — native macOS Expression app](../../swift/macos-avatar/)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -62,16 +62,9 @@
             "pages": [
               "introduction",
               "getting-started/quickstart",
-              "getting-started/models"
-            ]
-          },
-          {
-            "group": "Guides",
-            "pages": [
+              "getting-started/models",
               "getting-started/authentication",
-              "getting-started/pricing",
-              "guides/building-avatars",
-              "guides/deployment"
+              "getting-started/pricing"
             ]
           },
           {
@@ -96,10 +89,22 @@
             ]
           },
           {
-            "group": "Reference",
+            "group": "Guides",
+            "pages": [
+              "guides/building-avatars",
+              "guides/deployment"
+            ]
+          },
+          {
+            "group": "Concepts",
             "pages": [
               "getting-started/architecture",
-              "getting-started/device-matrix",
+              "getting-started/device-matrix"
+            ]
+          },
+          {
+            "group": "Changelog",
+            "pages": [
               "changelog"
             ]
           }

--- a/docs/examples/ai-conversation.mdx
+++ b/docs/examples/ai-conversation.mdx
@@ -1,5 +1,6 @@
 ---
-title: "AI voice chat with avatar"
+title: "AI voice chat"
+sidebarTitle: "AI voice chat"
 description: "Talk to an OpenAI Realtime voice agent and watch a bitHuman avatar lip-sync the response in real time."
 icon: "comments"
 ---
@@ -79,10 +80,10 @@ For a full web-based setup with LiveKit + a browser UI, run the [Docker Compose 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Apple-local agent" icon="apple" href="/examples/overview">
-    Full privacy — speech never leaves your Mac.
+  <Card title="macos-voice project" icon="apple" href="https://github.com/bithuman-product/bithuman-sdk-public/tree/main/Examples/swift/macos-voice">
+    Fully on-device voice agent — speech never leaves your Mac.
   </Card>
-  <Card title="Raspberry Pi" icon="microchip" href="/examples/overview">
-    Edge deployment on IoT devices.
+  <Card title="Device matrix" icon="microchip" href="/getting-started/device-matrix">
+    Edge targets — Raspberry Pi, Android, low-power hosts.
   </Card>
 </CardGroup>

--- a/docs/examples/cli-hello.mdx
+++ b/docs/examples/cli-hello.mdx
@@ -1,17 +1,18 @@
 ---
-title: "CLI Hello World"
-description: "Get an on-device AI avatar talking in 5 minutes — Homebrew install, doctor check, browser-served avatar, no code required."
+title: "CLI — Hello, avatar"
+sidebarTitle: "CLI — Hello, avatar"
+description: "Get an on-device AI avatar talking in ~2 minutes — install, doctor check, browser-served avatar, no code required."
 icon: "terminal"
 ---
 
-This page is the fastest way to try a real-time on-device avatar end-to-end.
-No code: just install the `bithuman` CLI, check your host, and open a
+The fastest way to try a real-time on-device avatar end-to-end.
+No code: install the `bithuman` CLI, check your host, and open a
 browser-served avatar on `localhost`. Audio is captured from your mic;
 lip-synced frames stream back over MJPEG.
 
 ## Prerequisites
 
-- macOS 26 (Tahoe) or later, Apple Silicon (M3+).
+- macOS 26+ (Apple Silicon M3+) **or** Linux x86_64 / aarch64.
 - ~3 GB free disk for voice mode, ~7 GB for the full local stack.
 - A bitHuman API key (free tier works). Sign in at
   [www.bithuman.ai → Developer → API Keys](https://www.bithuman.ai/#developer).
@@ -20,8 +21,11 @@ lip-synced frames stream back over MJPEG.
 ## 1. Install
 
 ```bash
-# Homebrew (recommended) — pulls onnxruntime / hdf5 / jpeg-turbo / webp / ffmpeg.
+# macOS — Homebrew (recommended). Pulls onnxruntime / hdf5 / jpeg-turbo / webp / ffmpeg.
 brew install bithuman-product/bithuman/bithuman
+
+# macOS / Linux — universal one-liner.
+curl -fsSL https://github.com/bithuman-product/homebrew-bithuman/releases/latest/download/install.sh | sh
 
 # Sanity-check host setup + API key presence.
 bithuman doctor
@@ -81,12 +85,12 @@ tune.
 
 <CardGroup cols={2}>
   <Card title="CLI reference" icon="book" href="/getting-started/cli">
-    All 13 subcommands, cache layout, exit codes.
+    Every subcommand, cache layout, exit codes.
   </Card>
-  <Card title="Halo macOS" icon="apple" href="/examples/overview">
-    Free signed DMG — floating avatar desktop app.
+  <Card title="Python — Hello, avatar" icon="python" href="/examples/python-hello">
+    The same engine, in ~20 lines of code.
   </Card>
-  <Card title="Swift quickstart" icon="rocket" href="/sdks/swift">
+  <Card title="Swift SDK" icon="rocket" href="/sdks/swift">
     Embed the same engine in a Mac / iPad / iPhone app.
   </Card>
   <Card title="Architecture" icon="diagram-project" href="/getting-started/architecture">

--- a/docs/examples/kotlin-android-hello.mdx
+++ b/docs/examples/kotlin-android-hello.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Kotlin / Android Hello World"
+title: "Kotlin / Android — Hello, avatar"
+sidebarTitle: "Kotlin / Android — Hello, avatar"
 description: "Render an on-device AI avatar on Android in ~20 lines of Kotlin — Maven Central AAR, arm64-v8a, fully private lip-sync."
 icon: "android"
 ---
@@ -78,16 +79,16 @@ That's the whole loop: 16 kHz mono PCM in, lip-synced `Bitmap`s out at
 ## Where to go next
 
 <CardGroup cols={2}>
-  <Card title="Kotlin SDK quickstart" icon="rocket" href="/sdks/kotlin">
-    Full Android Studio walkthrough.
+  <Card title="Kotlin SDK" icon="rocket" href="/sdks/kotlin">
+    Full walkthrough — API surface, streaming, `Fixture` + `Runtime`.
   </Card>
-  <Card title="Kotlin SDK overview" icon="book" href="/sdks/kotlin">
-    API surface, low-level `Fixture` + `Runtime` types.
+  <Card title="Flutter plugin" icon="mobile" href="/integrations/flutter">
+    Same runtime, one Dart codebase across mac / iOS / Android.
   </Card>
   <Card title="Device matrix" icon="microchip" href="/getting-started/device-matrix">
     Which phones, tablets, and SoCs have been benched.
   </Card>
-  <Card title="Architecture" icon="diagram-project" href="/getting-started/architecture">
-    How the AAR fits with the other SDKs.
+  <Card title="Models" icon="circle-info" href="/getting-started/models">
+    Essence vs Expression — which to ship.
   </Card>
 </CardGroup>

--- a/docs/examples/overview.mdx
+++ b/docs/examples/overview.mdx
@@ -1,32 +1,96 @@
 ---
 title: "Examples"
-description: "Runnable bitHuman examples — one per surface. Clone, set your API secret, run."
+description: "Runnable bitHuman projects, grouped by what you're building. Every one is open-source — clone, set your API secret, run."
 icon: "book-open"
 ---
 
-Every example is open-source under
+Every project below is open-source under
 [bithuman-sdk-public/Examples](https://github.com/bithuman-product/bithuman-sdk-public/tree/main/Examples).
-Pick the one closest to what you're building.
+Find the row that matches what you're building and start there.
+
+<Note>
+New here? The fastest end-to-end demo is the
+[CLI — Hello, avatar](/examples/cli-hello): one `brew install`, one
+command, a talking avatar in your browser. No code, ~2 minutes.
+</Note>
+
+## Start here — no code
 
 <CardGroup cols={2}>
-  <Card title="CLI — no code" icon="terminal" href="/examples/cli-hello">
-    `brew install` → `bithuman avatar`. Full demo, zero code. Start here.
+  <Card title="CLI — Hello, avatar" icon="terminal" href="/examples/cli-hello">
+    Install, `bithuman doctor`, `bithuman avatar`. Full demo, zero code.
   </Card>
+  <Card title="Quickstart project" icon="rocket" href="https://github.com/bithuman-product/bithuman-sdk-public/tree/main/Examples/quickstart">
+    The smallest scripted path — credentials, a model, your first render.
+  </Card>
+</CardGroup>
+
+## Backend & voice agents — Python
+
+The streaming runtime and LiveKit voice agents. Each repo project ships
+an `.env.example`, `requirements.txt`, and a `docker compose` stack.
+
+<CardGroup cols={2}>
   <Card title="Python — Hello, avatar" icon="python" href="/examples/python-hello">
-    Minimal `AsyncBithuman` streaming loop, ~20 lines.
+    The minimal `AsyncBithuman` streaming loop, ~20 lines.
   </Card>
+  <Card title="AI voice chat" icon="comments" href="/examples/ai-conversation">
+    OpenAI Realtime voice in, lip-synced avatar out. No server.
+  </Card>
+  <Card title="cloud-essence" icon="cloud" href="https://github.com/bithuman-product/bithuman-sdk-public/tree/main/Examples/python/cloud-essence">
+    Essence on bitHuman cloud + LiveKit + web UI. Start here for agents.
+  </Card>
+  <Card title="local-essence" icon="server" href="https://github.com/bithuman-product/bithuman-sdk-public/tree/main/Examples/python/local-essence">
+    Essence on your own CPU box. Includes a no-LiveKit `quickstart.py`.
+  </Card>
+  <Card title="cloud-expression" icon="cloud" href="https://github.com/bithuman-product/bithuman-sdk-public/tree/main/Examples/python/cloud-expression">
+    Expression on bitHuman cloud — a custom face per session.
+  </Card>
+  <Card title="local-expression-gpu" icon="microchip" href="https://github.com/bithuman-product/bithuman-sdk-public/tree/main/Examples/python/local-expression-gpu">
+    Expression on your own NVIDIA GPU, local LiveKit + Redis.
+  </Card>
+</CardGroup>
+
+## Native apps — Swift & Kotlin
+
+<CardGroup cols={2}>
   <Card title="Swift / iOS — Hello, avatar" icon="apple" href="/examples/swift-ios-hello">
     Minimal SwiftUI `bitHumanKit` integration, ~40 lines.
   </Card>
   <Card title="Kotlin / Android — Hello, avatar" icon="android" href="/examples/kotlin-android-hello">
     Maven AAR + `Avatar.load` in a fresh Android Studio project.
   </Card>
-  <Card title="AI conversation" icon="comments" href="/examples/ai-conversation">
-    OpenAI Realtime voice chat → talking avatar. The full loop.
+  <Card title="swift/macos-avatar" icon="apple" href="https://github.com/bithuman-product/bithuman-sdk-public/tree/main/Examples/swift/macos-avatar">
+    Full macOS voice agent with an on-device Expression avatar.
+  </Card>
+  <Card title="swift/macos-voice" icon="microphone" href="https://github.com/bithuman-product/bithuman-sdk-public/tree/main/Examples/swift/macos-voice">
+    Voice-only on-device agent — no avatar, no API key, fully offline.
+  </Card>
+  <Card title="swift/essence-playback" icon="apple" href="https://github.com/bithuman-product/bithuman-sdk-public/tree/main/Examples/swift/essence-playback">
+    SwiftUI Essence playback on macOS / iPad — audio-driven lip sync.
+  </Card>
+  <Card title="Flutter plugin" icon="mobile" href="/integrations/flutter">
+    One Dart codebase across macOS, iOS, and Android.
   </Card>
 </CardGroup>
 
-Building elsewhere? The [Flutter plugin](/integrations/flutter) and
-[REST API](/api-reference/overview) have their own end-to-end samples
-in the repo. For deployment shapes (LiveKit, GPU, embed) see
-[Deployment](/guides/deployment).
+## Web & other languages
+
+<CardGroup cols={2}>
+  <Card title="integrations/nextjs-ui" icon="react" href="https://github.com/bithuman-product/bithuman-sdk-public/tree/main/Examples/integrations/nextjs-ui">
+    A polished Next.js video-chat UI over LiveKit.
+  </Card>
+  <Card title="integrations/gradio-web" icon="globe" href="https://github.com/bithuman-product/bithuman-sdk-public/tree/main/Examples/integrations/gradio-web">
+    Talk to an avatar in the browser via Gradio + FastRTC.
+  </Card>
+  <Card title="integrations/java-websocket" icon="java" href="https://github.com/bithuman-product/bithuman-sdk-public/tree/main/Examples/integrations/java-websocket">
+    Stream audio to an avatar server from Java over WebSocket.
+  </Card>
+  <Card title="rest-api" icon="code" href="https://github.com/bithuman-product/bithuman-sdk-public/tree/main/Examples/rest-api">
+    `curl` and Python scripts for every REST endpoint.
+  </Card>
+</CardGroup>
+
+For deployment shapes (LiveKit cloud, self-hosted GPU, embed widget)
+see [Deployment](/guides/deployment). For the REST contract see the
+[API reference](/api-reference/overview).

--- a/docs/examples/python-hello.mdx
+++ b/docs/examples/python-hello.mdx
@@ -70,16 +70,16 @@ python quickstart.py --model /path/to/avatar.imx --audio-file speech.wav
 ## Where to go next
 
 <CardGroup cols={2}>
-  <Card title="Audio clip example" icon="play" href="/examples/python-hello">
-    Same idea, with OpenCV display and speaker playback wired up.
+  <Card title="local-essence project" icon="play" href="https://github.com/bithuman-product/bithuman-sdk-public/tree/main/Examples/python/local-essence">
+    The same loop with OpenCV display and speaker playback wired up.
   </Card>
-  <Card title="Live microphone" icon="microphone" href="/examples/python-hello">
-    Real-time mic input, low-latency lip-sync.
+  <Card title="Python SDK" icon="python" href="/sdks/python">
+    Full API surface, LiveKit agents, troubleshooting.
   </Card>
-  <Card title="AI conversation" icon="comments" href="/examples/ai-conversation">
+  <Card title="AI voice chat" icon="comments" href="/examples/ai-conversation">
     OpenAI Realtime voice chat driving the avatar.
   </Card>
-  <Card title="Python quickstart" icon="rocket" href="/getting-started/quickstart">
-    Deeper Python walkthrough with troubleshooting.
+  <Card title="Quickstart" icon="rocket" href="/getting-started/quickstart">
+    Credentials, a model, your first render in ~2 minutes.
   </Card>
 </CardGroup>

--- a/docs/examples/swift-ios-hello.mdx
+++ b/docs/examples/swift-ios-hello.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Swift / iOS — Hello, avatar"
+sidebarTitle: "Swift / iOS — Hello, avatar"
 description: "Render a real-time on-device bitHuman avatar on iPhone or iPad in ~40 lines of SwiftUI."
 icon: "apple"
 ---
@@ -97,14 +98,14 @@ A complete reference is at [Examples/swift/essence-playback](https://github.com/
 ## Where to go next
 
 <CardGroup cols={2}>
-  <Card title="Swift quickstart" icon="rocket" href="/sdks/swift">
-    Full SwiftUI walkthrough.
+  <Card title="Swift SDK" icon="rocket" href="/sdks/swift">
+    Full walkthrough — voice agent, lifecycle, entitlements.
   </Card>
-  <Card title="Swift iOS guide" icon="mobile" href="/sdks/swift">
-    Background mode, Picture-in-Picture, lifecycle.
+  <Card title="essence-playback project" icon="apple" href="https://github.com/bithuman-product/bithuman-sdk-public/tree/main/Examples/swift/essence-playback">
+    A complete runnable SwiftUI Essence reference app.
   </Card>
-  <Card title="Apple-local example" icon="laptop" href="/examples/overview">
-    Offline macOS voice agent.
+  <Card title="macos-voice project" icon="microphone" href="https://github.com/bithuman-product/bithuman-sdk-public/tree/main/Examples/swift/macos-voice">
+    Offline macOS voice agent — no avatar, no API key.
   </Card>
   <Card title="Device matrix" icon="microchip" href="/getting-started/device-matrix">
     Supported devices.

--- a/docs/getting-started/architecture.mdx
+++ b/docs/getting-started/architecture.mdx
@@ -17,7 +17,7 @@ bitHuman is shipped as a single cross-platform runtime with idiomatic SDKs in ea
 
 All four SDKs read the same `.imx` model file and produce identical output. Third-party dependencies are bundled inside the SDK — your app's `Package.swift` / `build.gradle.kts` / `requirements.txt` only needs the bithuman dependency.
 
-For the full install matrix and channel-by-channel snippets, see [Install](/getting-started/quickstart).
+For the full install matrix and channel-by-channel snippets, see the [Quickstart](/getting-started/quickstart).
 
 ## How the pieces fit together
 
@@ -132,16 +132,16 @@ A few choices shaped this architecture:
 ## Where to go next
 
 <CardGroup cols={2}>
-  <Card title="Install" icon="download" href="/getting-started/quickstart">
-    All install channels on one page
-  </Card>
   <Card title="Quickstart" icon="rocket" href="/getting-started/quickstart">
-    Get your first avatar running in 5 minutes
+    Your first avatar in ~2 minutes
+  </Card>
+  <Card title="SDKs" icon="cube" href="/sdks/python">
+    Python, Swift, Kotlin, Flutter, CLI
   </Card>
   <Card title="Models" icon="circle-info" href="/getting-started/models">
     Essence vs Expression
   </Card>
-  <Card title="Platforms" icon="desktop" href="/getting-started/device-matrix">
+  <Card title="Device matrix" icon="desktop" href="/getting-started/device-matrix">
     Per-platform details
   </Card>
 </CardGroup>

--- a/docs/getting-started/authentication.mdx
+++ b/docs/getting-started/authentication.mdx
@@ -144,6 +144,6 @@ Keys can be rotated from the [Developer dashboard](https://www.bithuman.ai/#deve
 ## Next
 
 - [Pricing & credits](/getting-started/pricing) — what each authenticated minute costs
-- [Quickstart](/getting-started/quickstart) — Python SDK in 5 minutes
-- [Swift SDK quickstart](/sdks/swift) — on-device in 10 minutes
+- [Quickstart](/getting-started/quickstart) — your first avatar in ~2 minutes
+- [Swift SDK](/sdks/swift) — on-device Mac / iPad / iPhone
 - [REST API overview](/api-reference/overview) — every endpoint with examples

--- a/docs/getting-started/cli.mdx
+++ b/docs/getting-started/cli.mdx
@@ -7,14 +7,14 @@ icon: "terminal"
 `bithuman` is a single binary that runs the avatar locally and gives you voice / text / browser-rendered avatar modes. Same commands on macOS, Linux, and Windows. The fastest way to see bitHuman in action — no code, no language toolchain.
 
 <Note>
-**Both Essence and Expression `.imx` models work in this one binary.** `bithuman avatar` auto-detects which model is in the file and uses the right backend automatically. For Expression with a runtime portrait swap, pass `--image <portrait.jpg>`.
+**Both Essence and Expression `.imx` models work in this one binary.** `bithuman avatar --model <file.imx>` auto-detects which model is in the file and uses the right backend automatically.
 </Note>
 
 ## When to use the CLI vs an SDK
 
 | You're… | Use |
 |---|---|
-| Trying bitHuman in 5 minutes without writing code | **CLI** |
+| Trying bitHuman in ~2 minutes without writing code | **CLI** |
 | Scripting a one-off render or batch job | **CLI** (`bithuman generate`) |
 | Wiring CI / smoke tests / shell pipelines | **CLI** |
 | Building a Python service or backend | **Python SDK** (`pip install bithuman`) |
@@ -59,12 +59,15 @@ The `avatar` subcommand exposes two transport modes:
 
 | Mode | Command | What it does |
 |---|---|---|
-| **Browser-served** (default) | `bithuman avatar [--identity <agent.imx>]` | Runs the avatar at `http://127.0.0.1:8080`. Browser captures the mic, the lip-synced video streams back. |
-| **Server-side voice loop** | `bithuman avatar --openai [--identity <agent.imx>]` | Captures the mic and plays back through your local speakers while the browser displays the avatar. Right when you want the OpenAI Realtime voice loop on a workstation without running audio in a browser tab. |
+| **Browser-served** (default) | `bithuman avatar [--model <agent.imx>]` | Runs the avatar at `http://127.0.0.1:8080`. Browser captures the mic, the lip-synced video streams back. |
+| **Server-side voice loop** | `bithuman avatar --openai [--model <agent.imx>]` | Captures the mic and plays back through your local speakers while the browser displays the avatar. Right when you want the OpenAI Realtime voice loop on a workstation without running audio in a browser tab. |
 
-For Expression with a runtime portrait swap, pass `--image <portrait.jpg>` alongside `--identity <expression.imx>`. For Essence, the avatar identity is baked into the `.imx` — no `--image` needed.
+Point `--model` at any `.imx` — Essence or Expression. The backend is
+auto-detected from the file; there is no separate flag to set the model
+type.
 
-If you omit `--identity`, the CLI uses the bundled sample avatar (Essence) and downloads it to `~/.cache/bithuman/models/` on first run.
+If you omit `--model`, the CLI uses the bundled sample avatar (Essence)
+and downloads it to `~/.cache/bithuman/models/` on first run.
 
 ## Subcommands
 
@@ -101,14 +104,14 @@ All subcommands accept `--help` for full flag listings.
 ## Where to go next
 
 <CardGroup cols={2}>
-  <Card title="CLI Hello World" icon="rocket" href="/examples/cli-hello">
-    First 5 minutes — install, doctor, avatar.
+  <Card title="CLI — Hello, avatar" icon="rocket" href="/examples/cli-hello">
+    First ~2 minutes — install, doctor, avatar.
   </Card>
   <Card title="Architecture" icon="diagram-project" href="/getting-started/architecture">
     How the CLI fits with the SDKs.
   </Card>
-  <Card title="Halo macOS" icon="apple" href="/examples/overview">
-    Signed-DMG desktop variant of the CLI (no Terminal).
+  <Card title="Examples" icon="book-open" href="/examples/overview">
+    Every runnable project, grouped by what you're building.
   </Card>
   <Card title="Pricing" icon="credit-card" href="/getting-started/pricing">
     Credits, plans, what's metered.

--- a/docs/getting-started/device-matrix.mdx
+++ b/docs/getting-started/device-matrix.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Device compatibility"
+title: "Device matrix"
+sidebarTitle: "Device matrix"
 description: "Which avatar runs on which device, with hardware floors for every supported platform."
 icon: "table-cells"
 ---
@@ -62,4 +63,4 @@ Frames are delivered at 1280×720 by every SDK; smaller avatars are letterboxed/
 - **GPU server** → Expression via the [self-hosted GPU container](/guides/deployment).
 - **No infrastructure** → [LiveKit Cloud Plugin](/guides/deployment). Either model.
 
-For full deployment scenarios with device, model, and network combinations together, see [Use cases](/getting-started/quickstart).
+For full deployment scenarios with device, model, and network combinations together, see [Deployment](/guides/deployment).

--- a/docs/getting-started/models.mdx
+++ b/docs/getting-started/models.mdx
@@ -49,7 +49,7 @@ Essence packages a complete avatar identity (face, body, gestures) into an `.imx
 
 **How to ship it**
 
-- [**Python SDK**](/getting-started/quickstart) — self-host on Linux/macOS/Windows.
+- [**Python SDK**](/sdks/python) — self-host on Linux/macOS/Windows.
 - [**Swift SDK**](/sdks/swift) — native Mac, iPad, iPhone apps.
 - [**Kotlin SDK**](/sdks/kotlin) — native Android apps.
 - [**Flutter plugin**](/integrations/flutter) — one Dart codebase across Mac, iOS, Android.
@@ -73,10 +73,9 @@ Expression generates real-time facial animation directly from a portrait image. 
 
 - [**Cloud LiveKit plugin**](/guides/deployment) — bitHuman hosts the GPU worker (set `model="expression"`).
 - [**Self-hosted GPU**](/guides/deployment) — your own NVIDIA GPU via the Docker container.
-- [**On-device macOS / iPadOS**](/examples/overview) — Apple Silicon M3+, via the Python or Swift SDK.
-- [**Mac reference app**](/examples/overview) — native macOS, drag-drop face swap.
-- [**iPad reference app**](/sdks/swift) — iPadOS, Picture-in-Picture support.
-- [**bitHuman CLI**](/getting-started/cli) — `bithuman avatar --image portrait.jpg`.
+- [**On-device macOS / iPadOS**](/sdks/swift) — Apple Silicon M3+, via the Swift SDK.
+- [**macos-avatar example**](https://github.com/bithuman-product/bithuman-sdk-public/tree/main/Examples/swift/macos-avatar) — a complete native macOS Expression app.
+- [**bitHuman CLI**](/getting-started/cli) — `bithuman avatar` with an Expression `.imx`.
 - [**REST API**](/api-reference/overview) — same endpoint as Essence; the model is selected per agent.
 
 ## Which should I use?
@@ -118,9 +117,9 @@ Expression generates real-time facial animation directly from a portrait image. 
 
 <CardGroup cols={2}>
   <Card title="Quickstart" icon="rocket" href="/getting-started/quickstart">
-    Get your first avatar running in 5 minutes
+    Get your first avatar running in ~2 minutes
   </Card>
-  <Card title="Platforms" icon="desktop" href="/getting-started/device-matrix">
+  <Card title="Device matrix" icon="desktop" href="/getting-started/device-matrix">
     Full per-platform support matrix
   </Card>
   <Card title="Pricing" icon="credit-card" href="/getting-started/pricing">

--- a/docs/getting-started/pricing.mdx
+++ b/docs/getting-started/pricing.mdx
@@ -52,25 +52,31 @@ If the device loses connectivity mid-session, the SDK has a **5-minute offline g
 ## Check your balance
 
 ```bash
-curl -X GET https://api.bithuman.ai/v2/credit-summaries \
+curl https://api.bithuman.ai/v2/credit-summaries \
   -H "api-secret: $BITHUMAN_API_SECRET"
 ```
 
 Response:
 ```json
 {
-  "balance": 1842,
-  "plan": "creator",
-  "renews_at": "2026-05-15T00:00:00Z",
-  "estimated_minutes": {
-    "essence_cloud": 921,
-    "expression_cloud": 460,
-    "expression_on_device": 921
+  "success": true,
+  "data": {
+    "balance": 5240,
+    "plan_credits": 240,
+    "topup_credits": 5000,
+    "minutes_estimate": {
+      "voice_chat": 524,
+      "video_chat": 174,
+      "standard_avatar_cloud": 2620,
+      "standard_avatar_self_hosted": 5240,
+      "advanced_avatar_cloud": 1310,
+      "advanced_avatar_self_hosted": 2620
+    }
   }
 }
 ```
 
-See [`/api-reference/credit-summaries`](/api-reference/overview) for the full schema.
+See [Credits & Billing](/api-reference/rate-limits) for the full schema.
 
 ## What's NOT billed
 

--- a/docs/integrations/flutter.mdx
+++ b/docs/integrations/flutter.mdx
@@ -1,435 +1,160 @@
 ---
 title: "Flutter plugin"
-description: "Ship a bitHuman avatar from one Dart codebase to macOS, iOS, and Android."
+sidebarTitle: "Flutter plugin"
+description: "Ship a real-time bitHuman avatar from one Dart codebase to macOS, iOS, and Android."
 icon: "mobile"
 ---
 
-Two ways to ship a bitHuman avatar with Flutter:
+The `bithuman` plugin wraps the Swift and Kotlin SDKs under one Dart
+API. Audio in, lip-synced video out at 25 FPS — fully on-device, with
+per-platform echo cancellation auto-selected for you. One codebase
+across **macOS, iOS, and Android**.
 
-1. **[The `bithuman` plugin](#bithuman-plugin-recommended)** — `flutter pub add bithuman`. One Dart codebase, on-device Essence avatar, three platforms (macOS, iOS, Android).
-2. **[LiveKit + Python agent stack](#flutter--livekit--python-stack)** — Flutter UI subscribes to a LiveKit room; a Python agent runs the avatar (Essence or Expression) on a server you control. Use this when the avatar is cloud-hosted or shared between participants.
+<Note>
+**Pub.dev publish is pending.** While the package is finalized, request
+the git-dependency URL on [Discord](https://discord.gg/ES953n7bPA), or
+watch the
+[bithuman-apps releases](https://github.com/bithuman-product/bithuman-apps/releases)
+for the publish announcement.
+</Note>
 
----
-
-## bithuman plugin (recommended)
-
-The plugin wraps the Swift and Kotlin SDKs under one Dart API. Built-in echo cancellation per platform — the right audio transport is auto-selected for you.
+## Install
 
 ```yaml
 # pubspec.yaml
 dependencies:
-  bithuman: ^1.0.0
+  bithuman: ^1.16.0
 ```
 
-<Note>
-Pub.dev publish is pending. While the package is finalized, request early access on [Discord](https://discord.gg/ES953n7bPA) or watch the [bithuman-sdk-public releases](https://github.com/bithuman-product/bithuman-sdk-public/releases) for the publish announcement.
-</Note>
+```bash
+flutter pub get
+```
+
+Auth: provide your `BITHUMAN_API_SECRET` to the app (env var in
+development, your own secret store in production). Get one at
+[Developer → API Keys](https://www.bithuman.ai/#developer).
+
+## Minimal usage
+
+Load an `.imx` model and host the avatar canvas. The plugin owns the
+runtime, audio capture, lip-sync, and echo cancellation.
 
 ```dart
+import 'package:flutter/material.dart';
 import 'package:bithuman/bithuman.dart';
 
-void main() => runApp(const MaterialApp(home: AvatarScreen()));
-```
-
-The plugin ships with a cross-platform example app demonstrating settings, prompt hot-reload, and the full Essence pipeline. For Expression on Apple Silicon (Mac and iPad), pair the plugin with the native Swift [Expression on Swift](/sdks/swift) guide — the Flutter plugin itself covers the Essence cross-platform path today.
-
----
-
-## Flutter + LiveKit + Python stack
-
-Use this architecture when the avatar runs on a server you control and the Flutter app is just a subscriber. Both Essence and Expression are valid choices for the Python agent — see the [LiveKit Cloud Plugin](/guides/deployment) guide.
-
-## Architecture
-
-```
-┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
-│   Flutter App   │    │   LiveKit Room  │    │  Python Agent   │
-│   Video View    │◄──►│  Real-time      │◄──►│  bitHuman       │
-│   Audio Capture │    │  Streaming      │    │  Avatar + LLM   │
-└─────────────────┘    └─────────────────┘    └─────────────────┘
-```
-
-- **Flutter App**: Cross-platform UI, camera/microphone capture, video rendering
-- **LiveKit Room**: Real-time media routing, participant management
-- **Python Agent**: AI conversation processing, avatar rendering
-
-## Prerequisites
-
-- Flutter SDK 3.0+
-- Python 3.11+
-- bitHuman API Secret
-- LiveKit Cloud account
-- OpenAI API Key
-
----
-
-## Quick Start
-
-<Steps>
-  <Step title="Project structure">
-    ```bash
-    mkdir flutter-bithuman-avatar
-    cd flutter-bithuman-avatar
-    mkdir -p backend frontend/lib
-    ```
-  </Step>
-  <Step title="Backend setup">
-    ```bash
-    cd backend
-    python3 -m venv .venv
-    source .venv/bin/activate
-    pip install "livekit-agents[openai,bithuman,silero]~=1.4" flask flask-cors python-dotenv
-    ```
-
-    Create `.env`:
-    ```bash
-    BITHUMAN_API_SECRET=your_api_secret
-    BITHUMAN_AGENT_ID=A33NZN6384
-    OPENAI_API_KEY=sk-proj_your_key_here
-    LIVEKIT_API_KEY=APIyour_key
-    LIVEKIT_API_SECRET=your_secret
-    LIVEKIT_URL=wss://your-project.livekit.cloud
-    ```
-  </Step>
-  <Step title="Frontend setup">
-    ```bash
-    cd ../frontend
-    flutter create . --org com.bithuman.avatar
-    ```
-
-    Update `pubspec.yaml` dependencies:
-    ```yaml
-    dependencies:
-      flutter:
-        sdk: flutter
-      livekit_components: 1.2.2+hotfix.1
-      livekit_client: ^2.5.3
-      provider: ^6.1.1
-      http: ^1.1.0
-    ```
-
-    ```bash
-    flutter pub get
-    ```
-  </Step>
-  <Step title="Run the system">
-    ```bash
-    # Terminal 1: Start Backend
-    cd backend && source .venv/bin/activate
-    python token_server.py &
-    python agent.py dev
-
-    # Terminal 2: Start Frontend
-    cd frontend
-    flutter run -d chrome --web-port 8080
-    ```
-  </Step>
-</Steps>
-
----
-
-## Token Server
-
-<Warning>
-LiveKit requires a JWT to join rooms. Never ship LiveKit API keys in client apps. Use a server endpoint to mint short-lived tokens.
-</Warning>
-
-```python token_server.py
-from flask import Flask, request, jsonify
-from livekit import api
-from datetime import timedelta
-import os
-from dotenv import load_dotenv
-
-load_dotenv()
-app = Flask(__name__)
-
-LIVEKIT_API_KEY = os.getenv("LIVEKIT_API_KEY")
-LIVEKIT_API_SECRET = os.getenv("LIVEKIT_API_SECRET")
-LIVEKIT_URL = os.getenv("LIVEKIT_URL")
-
-@app.route('/token', methods=['POST'])
-def create_token():
-    data = request.get_json() or {}
-    room = data.get('room', 'flutter-avatar-room')
-    identity = data.get('participant', 'Flutter User')
-
-    at = api.AccessToken(LIVEKIT_API_KEY, LIVEKIT_API_SECRET, identity=identity)
-    at.add_grant(api.VideoGrant(room_join=True, room=room))
-    at.ttl = timedelta(hours=1)
-
-    return jsonify({'token': at.to_jwt(), 'server_url': LIVEKIT_URL})
-
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=3000)
-```
-
----
-
-## Python Agent
-
-```python agent.py
-import os
-from dotenv import load_dotenv
-from livekit.agents import (
-    Agent,
-    AgentSession,
-    JobContext,
-    RoomOutputOptions,
-    WorkerOptions,
-    WorkerType,
-    cli,
-)
-from livekit.plugins import bithuman, openai, silero
-
-load_dotenv()
-
-async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-    await ctx.wait_for_participant()
-
-    avatar = bithuman.AvatarSession(
-        avatar_id=os.getenv("BITHUMAN_AGENT_ID"),
-        api_secret=os.getenv("BITHUMAN_API_SECRET"),
-    )
-
-    session = AgentSession(
-        llm=openai.realtime.RealtimeModel(
-            voice="coral",
-            model="gpt-4o-mini-realtime-preview",
-        ),
-        vad=silero.VAD.load(),
-    )
-
-    await avatar.start(session, room=ctx.room)
-
-    await session.start(
-        agent=Agent(
-            instructions="You are a helpful assistant. Respond concisely."
-        ),
-        room=ctx.room,
-        room_output_options=RoomOutputOptions(audio_enabled=False),
-    )
-
-if __name__ == "__main__":
-    cli.run_app(WorkerOptions(
-        entrypoint_fnc=entrypoint,
-        worker_type=WorkerType.ROOM,
-        job_memory_warn_mb=2000,
-        num_idle_processes=1,
-        initialize_process_timeout=180,
-    ))
-```
-
----
-
-## Flutter App
-
-### LiveKit Configuration
-
-```dart config/livekit_config.dart
-import 'dart:convert';
-import 'dart:math';
-import 'package:http/http.dart' as http;
-
-class LiveKitConfig {
-  static const String serverUrl = 'wss://your-project.livekit.cloud';
-  static const String? tokenEndpoint = 'http://localhost:3000/token';
-
-  static String get roomName {
-    const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
-    final random = Random();
-    return 'room-${String.fromCharCodes(
-      Iterable.generate(12, (_) => chars.codeUnitAt(random.nextInt(chars.length)))
-    )}';
-  }
-
-  static String get participantName {
-    const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
-    final random = Random();
-    return 'user-${String.fromCharCodes(
-      Iterable.generate(8, (_) => chars.codeUnitAt(random.nextInt(chars.length)))
-    )}';
-  }
-
-  static Future<String> getToken() async {
-    final response = await http.post(
-      Uri.parse(tokenEndpoint!),
-      headers: {'Content-Type': 'application/json'},
-      body: jsonEncode({
-        'room': roomName,
-        'participant': participantName,
-      }),
-    );
-    if (response.statusCode == 200) {
-      return jsonDecode(response.body)['token'] as String;
-    }
-    throw Exception('Token server returned ${response.statusCode}');
-  }
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  runApp(const MaterialApp(home: AvatarScreen()));
 }
-```
 
-### Main App
-
-```dart main.dart
-import 'package:flutter/material.dart';
-import 'package:livekit_client/livekit_client.dart' as lk;
-import 'package:livekit_components/livekit_components.dart';
-import 'config/livekit_config.dart';
-
-void main() => runApp(const BitHumanFlutterApp());
-
-class BitHumanFlutterApp extends StatelessWidget {
-  const BitHumanFlutterApp({super.key});
-
+class AvatarScreen extends StatefulWidget {
+  const AvatarScreen({super.key});
   @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'bitHuman Flutter Integration',
-      theme: LiveKitTheme().buildThemeData(context),
-      themeMode: ThemeMode.dark,
-      home: const ConnectionScreen(),
-    );
-  }
+  State<AvatarScreen> createState() => _AvatarScreenState();
 }
 
-class ConnectionScreen extends StatefulWidget {
-  const ConnectionScreen({super.key});
-
-  @override
-  State<ConnectionScreen> createState() => _ConnectionScreenState();
-}
-
-class _ConnectionScreenState extends State<ConnectionScreen> {
-  bool _isConnecting = false;
+class _AvatarScreenState extends State<AvatarScreen> {
+  BithumanAvatar? _avatar;
 
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) => _connect());
-  }
-
-  Future<void> _connect() async {
-    setState(() => _isConnecting = true);
-    final token = await LiveKitConfig.getToken();
-    if (!mounted) return;
-
-    Navigator.of(context).pushReplacement(
-      MaterialPageRoute(
-        builder: (_) => VideoRoomScreen(
-          url: LiveKitConfig.serverUrl,
-          token: token,
-          roomName: LiveKitConfig.roomName,
-        ),
-      ),
-    );
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      // imxPath: an .imx downloaded from Explore, bundled or on disk.
+      _avatar = await BithumanAvatar.load(imxPath);
+      setState(() {});
+    });
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: const Color(0xFF1a1a1a),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const CircularProgressIndicator(),
-            const SizedBox(height: 20),
-            Text(
-              _isConnecting ? 'Connecting...' : 'Failed',
-              style: const TextStyle(color: Colors.white70, fontSize: 18),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class VideoRoomScreen extends StatelessWidget {
-  final String url, token, roomName;
-  const VideoRoomScreen({
-    super.key, required this.url, required this.token, required this.roomName,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return LivekitRoom(
-      roomContext: RoomContext(
-        url: url,
-        token: token,
-        connect: true,
-        roomOptions: lk.RoomOptions(adaptiveStream: true, dynacast: true),
-      ),
-      builder: (context, roomCtx) {
-        return Scaffold(
-          appBar: AppBar(title: Text('Room: $roomName')),
-          backgroundColor: const Color(0xFF1a1a1a),
-          body: const Center(child: Text('AI Avatar Video Here')),
-        );
-      },
+      body: _avatar == null
+          ? const Center(child: CircularProgressIndicator())
+          : AvatarCanvas(avatar: _avatar!),
     );
   }
 }
 ```
 
----
+The plugin ships a complete cross-platform example app — settings,
+prompt hot-reload, and the full Essence pipeline on all three
+platforms. Use it as your reference integration.
 
-## Platform-Specific Setup
+For OpenAI Realtime voice chat (mic in → spoken reply → lip-synced
+avatar), import `package:bithuman/bithuman_realtime.dart`.
 
-### iOS (`ios/Runner/Info.plist`)
+<Note>
+The plugin covers the **Essence** cross-platform path today. For
+**Expression** on Apple Silicon (Mac and iPad), pair it with the
+native [Swift SDK](/sdks/swift).
+</Note>
 
-```xml
-<key>NSCameraUsageDescription</key>
-<string>Camera access for video calls with AI avatar</string>
-<key>NSMicrophoneUsageDescription</key>
-<string>Microphone access for voice interaction with AI avatar</string>
-```
+## Requirements
 
-### Android (`AndroidManifest.xml`)
+| Platform | Floor |
+|---|---|
+| **macOS** | Apple Silicon M3+, macOS 26+ |
+| **iOS / iPadOS** | iPhone 17 Pro+ or iPad Pro M4+, iOS 26+ |
+| **Android** | `arm64-v8a`, Android 10+ |
+| **Flutter** | 3.3+, Dart SDK 3.11+ |
 
-```xml
-<uses-permission android:name="android.permission.CAMERA" />
-<uses-permission android:name="android.permission.RECORD_AUDIO" />
-<uses-permission android:name="android.permission.INTERNET" />
-```
+Add the platform permission strings your app needs — microphone (all
+platforms), plus `com.apple.security.device.audio-input` for sandboxed
+macOS apps. The same iOS increased-memory entitlement the
+[Swift SDK](/sdks/swift) requires applies here.
 
----
+## Alternative: cloud-hosted via LiveKit
 
-## Deployment
+When the avatar should run on a server (shared between participants,
+or Expression on a GPU) rather than on-device, the Flutter app becomes
+a thin LiveKit subscriber and a Python agent runs the avatar. That's a
+deployment shape, not this plugin — start from the runnable stacks:
 
-<CodeGroup>
+<CardGroup cols={2}>
+  <Card title="cloud-essence" icon="cloud" href="https://github.com/bithuman-product/bithuman-sdk-public/tree/main/Examples/python/cloud-essence">
+    Essence on bitHuman cloud + LiveKit + web UI.
+  </Card>
+  <Card title="nextjs-ui" icon="react" href="https://github.com/bithuman-product/bithuman-sdk-public/tree/main/Examples/integrations/nextjs-ui">
+    A polished LiveKit video-chat front end to model yours on.
+  </Card>
+</CardGroup>
 
-```bash iOS
-flutter build ios --release
-```
-
-```bash Android
-flutter build apk --release
-```
-
-```bash Web
-flutter build web --release
-```
-
-</CodeGroup>
-
----
+The Flutter client side is the standard
+[`livekit_client`](https://pub.dev/packages/livekit_client) flow —
+mint a room token from a server you control, subscribe to the agent's
+video track. See [Deployment](/guides/deployment) for the full shape.
 
 ## Troubleshooting
 
-| Problem | Solution |
-|---------|----------|
-| Avatar session failed | Check bitHuman API secret and avatar ID |
-| Connection failed | Verify LiveKit server URL, ensure backend is running |
-| No camera found | Check device permissions |
-| Avatar not showing | Check backend logs, verify API key |
-| Shader compilation errors | Run `flutter clean && flutter pub get` |
+<AccordionGroup>
+  <Accordion title="Avatar never appears">
+    Confirm the `.imx` path resolves on-device and
+    `BITHUMAN_API_SECRET` is reachable from the running app, then check
+    the device meets the hardware floor above.
+  </Accordion>
+  <Accordion title="App killed mid-conversation on iOS">
+    Missing the increased-memory-limit entitlement — see the
+    [Swift SDK](/sdks/swift) warning; it must be approved by Apple
+    before it takes effect.
+  </Accordion>
+  <Accordion title="Build fails after adding the dependency">
+    `flutter clean && flutter pub get`, then rebuild. On iOS/macOS run
+    `pod install` in the platform directory if pods are stale.
+  </Accordion>
+</AccordionGroup>
 
----
+## See also
 
-## Resources
-
-- [Flutter Documentation](https://docs.flutter.dev)
-- [LiveKit Flutter SDK](https://pub.dev/packages/livekit_client)
-- [LiveKit Agents Documentation](https://docs.livekit.io/agents)
+<CardGroup cols={3}>
+  <Card title="Swift SDK" icon="apple" href="/sdks/swift">
+    The native layer this plugin wraps on Apple
+  </Card>
+  <Card title="Kotlin SDK" icon="android" href="/sdks/kotlin">
+    The native layer this plugin wraps on Android
+  </Card>
+  <Card title="Models" icon="circle-info" href="/getting-started/models">
+    Essence vs Expression
+  </Card>
+</CardGroup>

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -144,7 +144,7 @@ code, no language toolchain.
     curl -X POST https://api.bithuman.ai/v1/agent/AGENT_CODE/speak \
       -H "api-secret: $BITHUMAN_API_SECRET" \
       -H "content-type: application/json" \
-      -d '{"message": "Hello from the REST API."}'
+      -d '{"text": "Hello from the REST API."}'
     ```
 
     [API reference →](/api-reference/overview)

--- a/docs/sdks/kotlin.mdx
+++ b/docs/sdks/kotlin.mdx
@@ -136,8 +136,8 @@ unsupported for production until measured.
 ## See also
 
 <CardGroup cols={3}>
-  <Card title="Android hello-world" icon="android" href="/examples/kotlin-android-hello">
-    Runnable project under `Examples/`
+  <Card title="Kotlin / Android — Hello, avatar" icon="android" href="/examples/kotlin-android-hello">
+    The minimal Kotlin integration, ~20 lines
   </Card>
   <Card title="Models" icon="circle-info" href="/getting-started/models">
     Essence vs Expression

--- a/docs/sdks/python.mdx
+++ b/docs/sdks/python.mdx
@@ -153,8 +153,8 @@ loop with no LiveKit, if you bring your own transport. Wiring details:
 ## See also
 
 <CardGroup cols={3}>
-  <Card title="Examples" icon="book-open" href="/examples/python-hello">
-    Audio clip, mic, AI conversation
+  <Card title="Examples" icon="book-open" href="/examples/overview">
+    Every runnable project, grouped by goal
   </Card>
   <Card title="Models" icon="circle-info" href="/getting-started/models">
     Essence vs Expression

--- a/docs/sdks/swift.mdx
+++ b/docs/sdks/swift.mdx
@@ -165,8 +165,8 @@ Requires Xcode 26+ (older Xcodes reject the Swift 6 concurrency syntax).
 ## See also
 
 <CardGroup cols={3}>
-  <Card title="iOS hello-world" icon="mobile" href="/examples/swift-ios-hello">
-    Runnable project under `Examples/swift/`
+  <Card title="Swift / iOS — Hello, avatar" icon="mobile" href="/examples/swift-ios-hello">
+    The minimal SwiftUI integration, ~40 lines
   </Card>
   <Card title="Models" icon="circle-info" href="/getting-started/models">
     Essence vs Expression


### PR DESCRIPTION
Full accuracy + design pass on docs.bithuman.ai and the CLI examples, from a page-by-page audit plus running every example end-to-end with real credentials.

## Docs site (commit 1 — 18 files)
- **Dead links eliminated.** Self-referential cards (`python-hello` → itself) and phantom pages (`Halo macOS`, `Apple-local`, `Raspberry Pi`, `Install`, `Use cases`, `credit-summaries`) repointed to real targets or removed.
- **One name per concept** across nav, H1, sidebar, and every inbound card. Retired the overloaded "Reference" group; added `Concepts` + `Changelog`; moved auth/pricing into `Get started`.
- **Contradictions fixed:** time-to-value standardized to ~2 min; the macOS-only vs macOS+Linux CLI claim reconciled.
- **Correctness bugs fixed:** wrong REST `/speak` body (`message` → `text`, per `openapi.yaml`); `cli.mdx` documented `--identity`/`--image` flags that don't exist (real flag is `--model`); `pricing.mdx` had a fabricated `credit-summaries` response — replaced with the real verified schema.
- **Examples section rebuilt** into a project gallery grouped by intent, surfacing the ~20 real runnable projects that were invisible before.
- **`integrations/flutter` rewritten** to house style (real `BithumanAvatar` API at `^1.16.0`); dropped the 250-line non-functional placeholder app.

## CLI examples (commit 2 — 4 files)
Verified against the shipped binary:
- `Examples/cli/README.md`: the `bithuman` command ships via Homebrew, **not** pip (pip's console script is `essence-render`). Removed fictional `demo`/`validate`/`convert`/`pack` subcommands and the nonexistent `bithuman-cli --agent-id/--mode` app. `stream` is HTTP/MJPEG on port 3001 (not WebSocket on 8765).
- `live-stream.sh` / `mac-app.sh` rewritten to invoke the real CLI.
- `local-expression-mac/README.md`: `bithuman demo` doesn't exist (use `generate`, or `quickstart.py` for face override); fixed 3 dead doc links.

## Verified working (real credentials, M5)
CLI (`doctor`/`info`/`generate`/`text`/`stream`/`speak`), REST read scripts, `local-essence/quickstart.py`, `Examples/quickstart`. `AsyncAvatar`/`AsyncBithuman` confirmed to be the same class (alias) — no code change needed. `gradio-web/.env.example` confirmed present — no change needed.

Preview locally: `cd docs && npx mintlify@latest dev`