### PR TITLE
docs: re-audit corrections (REST /speak payload + Flutter version)

### DIFF
--- a/docs/getting-started/authentication.mdx
+++ b/docs/getting-started/authentication.mdx
@@ -72,7 +72,7 @@ Pass the `api-secret` header on every request:
 curl -X POST https://api.bithuman.ai/v1/agent/A78WKV4515/speak \
   -H "api-secret: $BITHUMAN_API_SECRET" \
   -H "content-type: application/json" \
-  -d '{"text": "Hello"}'
+  -d '{"message": "Hello"}'
 ```
 
 ### Swift SDK (`bitHumanKit`)

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -122,7 +122,7 @@ code, no language toolchain.
     ```yaml
     # pubspec.yaml
     dependencies:
-      bithuman: ^1.0.0
+      bithuman: ^1.16.0
     ```
 
     One Dart codebase across macOS, iOS, and Android, with built-in
@@ -144,7 +144,7 @@ code, no language toolchain.
     curl -X POST https://api.bithuman.ai/v1/agent/AGENT_CODE/speak \
       -H "api-secret: $BITHUMAN_API_SECRET" \
       -H "content-type: application/json" \
-      -d '{"text": "Hello from the REST API."}'
+      -d '{"message": "Hello from the REST API."}'
     ```
 
     [API reference →](/api-reference/overview)


### PR DESCRIPTION
Second independent audit pass over the now-live docs. Caught and fixed 3 defects:

1. **`/speak` payload regression (high).** The PR #10 change to `introduction.mdx` flipped the correct `{"message": ...}` to `{"text": ...}`. The OpenAPI contract's `/v1/agent/{agent_code}/speak` `requestBody` is `required: ['message']`, and the dedicated `api-reference/agent-context.mdx` reference uses `message`. Reverted.
2. **`authentication.mdx` `/speak` bug (high).** Pre-existing `{"text": "Hello"}` — never caught in pass 1. Fixed to `message`.
3. **Flutter version inconsistency (medium).** `introduction.mdx` Flutter tab pinned `^1.0.0`; everything else (rewritten Flutter page, changelog) is `^1.16.0`. Aligned.

Independently verified clean: zero broken internal links, zero broken GitHub gallery links, no residual stale CLI flags / `figure_id` / contradictory time claims, version strings consistent, nav regroup intact.

Residual (reported, not changed — needs a product call): `pricing.mdx` vs `api-reference/rate-limits.mdx` use different vocabulary for the same credit tiers (Essence/Expression vs Standard/Advanced Avatar) and pricing omits the Dynamics-generation one-time cost.