### PR TITLE
docs: standardize credit terminology to Essence/Expression

### DIFF
--- a/docs/api-reference/rate-limits.mdx
+++ b/docs/api-reference/rate-limits.mdx
@@ -39,6 +39,15 @@ curl https://api.bithuman.ai/v2/credit-summaries \
 | `topup_credits` | Purchased credits — carry over until used |
 | `minutes_estimate` | Pre-calculated minutes remaining per session type |
 
+The `minutes_estimate` keys are the literal API field names; they map to
+the avatar models as follows:
+
+| API key | Model · where |
+|---|---|
+| `standard_avatar_cloud` / `standard_avatar_self_hosted` | **Essence** · bitHuman cloud / your hardware |
+| `advanced_avatar_cloud` / `advanced_avatar_self_hosted` | **Expression** · bitHuman cloud / your hardware |
+| `voice_chat` / `video_chat` | Managed cloud conversational agent (no avatar / with camera) |
+
 ---
 
 ## Credit Rates
@@ -47,12 +56,12 @@ Different features consume credits at different rates per minute:
 
 | Feature | Credits/min | Description |
 |---------|------------|-------------|
-| **Voice Chat** | 10 | Cloud agent with STT + LLM + TTS |
-| **Video Chat** | 30 | Cloud agent with user camera enabled |
-| **Standard Avatar (Cloud)** | 2 | Cloud-hosted avatar rendering |
-| **Standard Avatar (Self-Hosted)** | 1 | Your infrastructure, avatar rendering |
-| **Advanced Avatar (Cloud)** | 4 | Cloud-hosted high-quality avatar rendering |
-| **Advanced Avatar (Self-Hosted)** | 2 | Your infrastructure, high-quality avatar rendering |
+| **Voice Chat** | 10 | Managed cloud conversational agent — STT + LLM + TTS, no avatar |
+| **Video Chat** | 30 | Managed cloud conversational agent with user camera enabled |
+| **Essence — Cloud** | 2 | Essence avatar rendering on bitHuman's servers |
+| **Essence — Self-hosted** | 1 | Essence avatar rendering on your hardware |
+| **Expression — Cloud** | 4 | Expression avatar rendering on bitHuman's servers |
+| **Expression — Self-hosted** | 2 | Expression avatar rendering on your hardware |
 
 One-time costs:
 

--- a/docs/getting-started/pricing.mdx
+++ b/docs/getting-started/pricing.mdx
@@ -17,6 +17,7 @@ bitHuman bills in **credits** consumed per **active minute** of avatar runtime. 
 | **On-device (Swift SDK)** | Expression | 2 cr/min | Active avatar minutes only |
 | **On-device (Swift SDK), audio-only** | — | **Free** | No avatar, no metering |
 | **Agent generation** | — | 250 cr (one-time) | Per `.imx` model built from your photo / video |
+| **Dynamics generation** | — | 250 cr (one-time) | Per gesture / movement set generated for an agent |
 
 A "credit minute" is wall-clock time the engine is actively producing frames (or, on-device, the wall-clock time between `chat.start()` and `chat.stop()` with avatar attached). Idle / paused / disconnected time isn't billed.
 
@@ -75,6 +76,12 @@ Response:
   }
 }
 ```
+
+The `minutes_estimate` keys are the literal API field names and map to
+the avatar models: `standard_avatar_*` = **Essence**,
+`advanced_avatar_*` = **Expression** (`cloud` = bitHuman-hosted,
+`self_hosted` = your hardware). `voice_chat` / `video_chat` are the
+managed cloud conversational-agent rates, not avatar models.
 
 See [Credits & Billing](/api-reference/rate-limits) for the full schema.
 


### PR DESCRIPTION
Closes the parked terminology divergence: `pricing.mdx` and `api-reference/rate-limits.mdx` described the same credit tiers with different names.

- **rate-limits.mdx**: `Standard Avatar` → **Essence**, `Advanced Avatar` → **Expression** (Cloud / Self-hosted), matching the canonical site vocabulary used everywhere else.
- **Both pages**: added an explicit mapping table from the literal `minutes_estimate` JSON keys to the models. The JSON keys (`standard_avatar_*`, `advanced_avatar_*`, `voice_chat`, `video_chat`) are **kept verbatim** — they are the real server response fields (verified against the live API); only the human-facing labels changed. Clarified that `voice_chat`/`video_chat` are managed conversational-agent rates, not avatar models.
- **pricing.mdx**: added the missing `Dynamics generation — 250 cr (one-time)` row.

Verified: zero residual "Standard/Advanced Avatar" in human text; Essence (2 cloud / 1 self-hosted) and Expression (4 cloud / 2 self-hosted) rates reconcile across both pages.