### PR TITLE
docs+examples: fix newcomer blockers found by fresh-dev run

### DIFF
--- a/Examples/python/local-essence/conversation.py
+++ b/Examples/python/local-essence/conversation.py
@@ -133,7 +133,7 @@ async def main():
     bithuman_task = asyncio.create_task(push_to_bithuman())
 
     try:
-        async for frame in runtime.run(idle_timeout=0.5):
+        async for frame in runtime.run():
             if frame.has_image:
                 cv2.imshow("bitHuman", frame.bgr_image)
                 if cv2.waitKey(1) & 0xFF == ord("q"):

--- a/Examples/python/local-essence/microphone.py
+++ b/Examples/python/local-essence/microphone.py
@@ -123,7 +123,7 @@ async def main():
 
     fps = FPSController(target_fps=25)
     try:
-        async for frame in runtime.run(idle_timeout=0.5):
+        async for frame in runtime.run():
             sleep_time = fps.wait_next_frame(sleep=False)
             if sleep_time > 0:
                 await asyncio.sleep(sleep_time)

--- a/Examples/python/local-essence/requirements.txt
+++ b/Examples/python/local-essence/requirements.txt
@@ -5,4 +5,5 @@ livekit-plugins-bithuman>=1.4
 openai>=1.0
 loguru>=0.7.0
 sounddevice>=0.4
+opencv-python>=4.8
 numpy>=1.24

--- a/docs/api-reference/rate-limits.mdx
+++ b/docs/api-reference/rate-limits.mdx
@@ -17,16 +17,19 @@ curl https://api.bithuman.ai/v2/credit-summaries \
 {
   "success": true,
   "data": {
+    "user_id": "1f09e2f0-bffd-4201-a3e7-e98a9e432e67",
     "balance": 5240,
     "plan_credits": 240,
     "topup_credits": 5000,
+    "is_enterprise": false,
+    "isEnterprisePlanUser": false,
     "minutes_estimate": {
       "voice_chat": 524,
-      "video_chat": 174,
-      "standard_avatar_cloud": 2620,
-      "standard_avatar_self_hosted": 5240,
-      "advanced_avatar_cloud": 1310,
-      "advanced_avatar_self_hosted": 2620
+      "camera_chat": 174,
+      "essence_cloud": 2620,
+      "essence_self_hosted": 5240,
+      "expression_cloud": 1310,
+      "expression_self_hosted": 2620
     }
   }
 }
@@ -34,19 +37,21 @@ curl https://api.bithuman.ai/v2/credit-summaries \
 
 | Field | Description |
 |-------|-------------|
+| `user_id` | Account identifier |
 | `balance` | Total usable credits (plan + topup) |
 | `plan_credits` | Monthly subscription credits — reset each billing cycle |
 | `topup_credits` | Purchased credits — carry over until used |
+| `is_enterprise` / `isEnterprisePlanUser` | Whether the account is on an enterprise plan |
 | `minutes_estimate` | Pre-calculated minutes remaining per session type |
 
-The `minutes_estimate` keys are the literal API field names; they map to
-the avatar models as follows:
+`minutes_estimate` keys map directly to the two avatar models and the
+managed conversational agent:
 
-| API key | Model · where |
+| Key | Meaning |
 |---|---|
-| `standard_avatar_cloud` / `standard_avatar_self_hosted` | **Essence** · bitHuman cloud / your hardware |
-| `advanced_avatar_cloud` / `advanced_avatar_self_hosted` | **Expression** · bitHuman cloud / your hardware |
-| `voice_chat` / `video_chat` | Managed cloud conversational agent (no avatar / with camera) |
+| `essence_cloud` / `essence_self_hosted` | **Essence** · bitHuman cloud / your hardware |
+| `expression_cloud` / `expression_self_hosted` | **Expression** · bitHuman cloud / your hardware |
+| `voice_chat` / `camera_chat` | Managed cloud conversational agent (no avatar / with camera) |
 
 ---
 
@@ -57,7 +62,7 @@ Different features consume credits at different rates per minute:
 | Feature | Credits/min | Description |
 |---------|------------|-------------|
 | **Voice Chat** | 10 | Managed cloud conversational agent — STT + LLM + TTS, no avatar |
-| **Video Chat** | 30 | Managed cloud conversational agent with user camera enabled |
+| **Camera Chat** | 30 | Managed cloud conversational agent with user camera enabled |
 | **Essence — Cloud** | 2 | Essence avatar rendering on bitHuman's servers |
 | **Essence — Self-hosted** | 1 | Essence avatar rendering on your hardware |
 | **Expression — Cloud** | 4 | Expression avatar rendering on bitHuman's servers |

--- a/docs/examples/ai-conversation.mdx
+++ b/docs/examples/ai-conversation.mdx
@@ -10,12 +10,6 @@ A full voice-driven conversation: your mic feeds OpenAI Realtime, the AI's spoke
 ## Quick start
 
 <Steps>
-  <Step title="Install">
-    ```bash
-    pip install bithuman --upgrade openai sounddevice loguru
-    ```
-    <Note>The SDK pulls in `opencv-python-headless` automatically. Don't install full `opencv-python` separately.</Note>
-  </Step>
   <Step title="Get accounts">
     - **bitHuman** — [www.bithuman.ai](https://www.bithuman.ai)
     - **OpenAI** — [openai.com](https://openai.com)
@@ -26,11 +20,23 @@ A full voice-driven conversation: your mic feeds OpenAI Realtime, the AI's spoke
     export OPENAI_API_KEY="your_openai_key"
     ```
   </Step>
-  <Step title="Run">
+  <Step title="Get the code + install deps">
     ```bash
     git clone https://github.com/bithuman-product/bithuman-sdk-public.git
     cd bithuman-sdk-public/Examples/python/local-essence
-    python conversation.py --model /path/to/avatar.imx
+    python3 -m venv .venv && source .venv/bin/activate
+    pip install -r requirements.txt        # bithuman, openai, opencv, …
+    ```
+    Use a virtualenv — the example's `requirements.txt` pulls everything
+    it needs (the SDK itself ships no OpenCV; the display window does).
+  </Step>
+  <Step title="Run">
+    You need an avatar `.imx`. Easiest: run `bithuman avatar` once (it
+    caches a sample at `~/.cache/bithuman/models/sample-avatar.imx`), or
+    download one from [Explore](https://www.bithuman.ai/#explore).
+
+    ```bash
+    python conversation.py --model ~/.cache/bithuman/models/sample-avatar.imx
     ```
     Speak into your mic. The AI responds, the avatar lip-syncs in real time. Press `Q` to quit.
 

--- a/docs/examples/cli-hello.mdx
+++ b/docs/examples/cli-hello.mdx
@@ -73,8 +73,11 @@ responses through the default output device, and print transcripts.
 ## 5. Offline batch render
 
 ```bash
-# Render an MP4 from a model + WAV file, no interactive session.
-bithuman generate avatar.imx --audio speech.wav --output rendered.mp4
+# Make a quick WAV, then render an MP4 — no interactive session.
+# Step 2 already cached the sample model; or use any .imx you have.
+bithuman tts "Hello from bitHuman." --output speech.wav
+bithuman generate ~/.cache/bithuman/models/sample-avatar.imx \
+  --audio speech.wav --output rendered.mp4
 ```
 
 Default canvas is 1280×720 (letterboxed for non-matching fixture

--- a/docs/examples/kotlin-android-hello.mdx
+++ b/docs/examples/kotlin-android-hello.mdx
@@ -33,7 +33,7 @@ android {
 }
 
 dependencies {
-    implementation("ai.bithuman:sdk:1.17.3")   // Maven Central
+    implementation("ai.bithuman:sdk:1.17.1")   // Maven Central
 }
 ```
 

--- a/docs/examples/python-hello.mdx
+++ b/docs/examples/python-hello.mdx
@@ -8,14 +8,24 @@ The smallest runnable Python program that drives a bitHuman avatar. Audio in, li
 
 ## Prerequisites
 
-- Python 3.9+ (3.9–3.14 wheels).
+- Python 3.9+ (3.9–3.14 wheels). Use a virtualenv.
 - A bitHuman API secret — get one at [Developer → API Keys](https://www.bithuman.ai/#developer).
-- A `.imx` model file — download one from [Explore](https://www.bithuman.ai/#explore).
 
 ```bash
+python3 -m venv .venv && source .venv/bin/activate
 pip install bithuman --upgrade
 export BITHUMAN_API_SECRET=your_secret
 ```
+
+You also need two input files the script below references by name:
+
+- **`avatar.imx`** — an avatar model. Download one from
+  [Explore](https://www.bithuman.ai/#explore), or run `bithuman avatar`
+  once (the [CLI](/getting-started/cli) caches a sample at
+  `~/.cache/bithuman/models/sample-avatar.imx` — copy it next to your
+  script as `avatar.imx`).
+- **`speech.wav`** — any speech clip. Make one with the CLI:
+  `bithuman tts "Hello from bitHuman." --output speech.wav`.
 
 ## Minimal example
 
@@ -59,12 +69,19 @@ Run it:
 python hello.py
 ```
 
-To **see** the frames live (OpenCV display + speaker playback), copy the canonical example:
+This program **prints nothing and exits 0** — it renders frames into
+`frame.bgr_image` but doesn't display them. That's expected; it's the
+minimal loop. To actually *see* the avatar, use the canonical example,
+which adds an OpenCV window + speaker playback:
 
 ```bash
 git clone https://github.com/bithuman-product/bithuman-sdk-public.git
 cd bithuman-sdk-public/Examples/python/local-essence
-python quickstart.py --model /path/to/avatar.imx --audio-file speech.wav
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt      # incl. opencv — not bundled with the SDK
+python quickstart.py \
+  --model ~/.cache/bithuman/models/sample-avatar.imx \
+  --audio-file speech.wav            # this example dir ships a speech.wav
 ```
 
 ## Where to go next

--- a/docs/getting-started/pricing.mdx
+++ b/docs/getting-started/pricing.mdx
@@ -62,26 +62,29 @@ Response:
 {
   "success": true,
   "data": {
+    "user_id": "1f09e2f0-bffd-4201-a3e7-e98a9e432e67",
     "balance": 5240,
     "plan_credits": 240,
     "topup_credits": 5000,
+    "is_enterprise": false,
+    "isEnterprisePlanUser": false,
     "minutes_estimate": {
       "voice_chat": 524,
-      "video_chat": 174,
-      "standard_avatar_cloud": 2620,
-      "standard_avatar_self_hosted": 5240,
-      "advanced_avatar_cloud": 1310,
-      "advanced_avatar_self_hosted": 2620
+      "camera_chat": 174,
+      "essence_cloud": 2620,
+      "essence_self_hosted": 5240,
+      "expression_cloud": 1310,
+      "expression_self_hosted": 2620
     }
   }
 }
 ```
 
-The `minutes_estimate` keys are the literal API field names and map to
-the avatar models: `standard_avatar_*` = **Essence**,
-`advanced_avatar_*` = **Expression** (`cloud` = bitHuman-hosted,
-`self_hosted` = your hardware). `voice_chat` / `video_chat` are the
-managed cloud conversational-agent rates, not avatar models.
+The `minutes_estimate` keys are the two avatar models directly:
+`essence_*` = **Essence**, `expression_*` = **Expression** (`cloud` =
+bitHuman-hosted, `self_hosted` = your hardware). `voice_chat` /
+`camera_chat` are the managed cloud conversational-agent estimates, not
+avatar models.
 
 See [Credits & Billing](/api-reference/rate-limits) for the full schema.
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -38,16 +38,28 @@ bithuman doctor          # confirms host + key are good
 
 ## 3. Make it talk
 
-```bash
-# Render a video from any WAV — no code.
-bithuman generate avatar.imx --audio speech.wav --output demo.mp4
+The fastest check needs no files — this fetches a sample avatar on
+first run and serves it in your browser:
 
-# Or a live spoken conversation (cloud LLM/voice).
+```bash
+bithuman avatar          # open http://127.0.0.1:8080, grant mic, talk
+```
+
+Or hold a spoken conversation (cloud LLM + voice):
+
+```bash
 export OPENAI_API_KEY=sk-...
 bithuman voice
+```
 
-# Or the avatar in your browser at http://127.0.0.1:8080.
-bithuman avatar
+Or render an MP4 offline. `generate` needs an `.imx` model and a WAV —
+make a quick WAV with the built-in TTS, and reuse the sample the step
+above cached (or any `.imx` you downloaded from Explore):
+
+```bash
+bithuman tts "Hello from bitHuman." --output speech.wav
+bithuman generate ~/.cache/bithuman/models/sample-avatar.imx \
+  --audio speech.wav --output demo.mp4
 ```
 
 Open `demo.mp4` — that's a lip-synced talking avatar, end to end.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -107,7 +107,7 @@ code, no language toolchain.
         ndk { abiFilters += setOf("arm64-v8a") }
         minSdk = 29
     } }
-    dependencies { implementation("ai.bithuman:sdk:1.17.3") }
+    dependencies { implementation("ai.bithuman:sdk:1.17.1") }
     ```
 
     ```kotlin

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -161,14 +161,16 @@ and an avatar `.imx` from the
 
 <AccordionGroup>
   <Accordion title="Render a talking-head video from a script" icon="film">
-    One command, no code:
+    No code — make a WAV, then render an MP4:
 
     ```bash
+    bithuman tts "Hello from bitHuman." --output speech.wav
     bithuman generate avatar.imx --audio speech.wav --output demo.mp4
     ```
 
-    Batch-render at scale by looping over scripts. The same path is
-    available in every SDK via the streaming API.
+    `avatar.imx` is any model you downloaded from Explore (or the
+    sample the CLI caches on first `bithuman avatar`). Batch-render at
+    scale by looping over scripts; the same path is in every SDK.
   </Accordion>
 
   <Accordion title="Have a spoken conversation" icon="microphone">

--- a/docs/sdks/kotlin.mdx
+++ b/docs/sdks/kotlin.mdx
@@ -21,12 +21,12 @@ android {
         minSdk = 29
     }
 }
-dependencies { implementation("ai.bithuman:sdk:1.17.3") }
+dependencies { implementation("ai.bithuman:sdk:1.17.1") }
 ```
 
 | Field | Value |
 |---|---|
-| Maven coord | `ai.bithuman:sdk:1.17.3` |
+| Maven coord | `ai.bithuman:sdk:1.17.1` |
 | ABI | `arm64-v8a` only |
 | Min / Compile SDK | 29 (Android 10) / 35 |
 | NDK | 28.0.13004108 |

--- a/docs/sdks/python.mdx
+++ b/docs/sdks/python.mdx
@@ -19,9 +19,10 @@ Python 3.9+ (3.9–3.14 wheels). Wheels: macOS arm64, Linux x86_64, Linux aarch6
 Windows x86_64.
 
 <Note>
-The wheel pulls `opencv-python-headless`. Don't also install full
-`opencv-python` — it conflicts with PyAV and triggers FFmpeg warnings
-on macOS.
+The SDK returns frames as numpy BGR arrays and needs **no** OpenCV
+itself. Only the example scripts that *display* a window
+(`quickstart.py`, `conversation.py`) need `opencv-python` — it's in
+each example's `requirements.txt`.
 </Note>
 
 Auth: export `BITHUMAN_API_SECRET`. Get a secret at
@@ -90,7 +91,7 @@ For a real-time WebRTC voice agent with an avatar, use the
 the runtime yourself:
 
 ```bash
-pip install "bithuman[agent]"     # pulls livekit-plugins-bithuman
+pip install livekit-plugins-bithuman   # pulls bithuman + livekit-agents
 ```
 
 ```python

--- a/docs/sdks/python.mdx
+++ b/docs/sdks/python.mdx
@@ -75,9 +75,11 @@ adds OpenCV display + speaker playback on top of this loop.
 
 ## No-code render
 
-For one-shot or batch video, skip the SDK entirely:
+For one-shot or batch video, skip the SDK entirely. `generate` needs an
+`.imx` and a WAV (`bithuman tts` can make the WAV):
 
 ```bash
+bithuman tts "Hello from bitHuman." --output speech.wav
 bithuman generate avatar.imx --audio speech.wav --output demo.mp4
 ```
 


### PR DESCRIPTION
Validated docs.bithuman.ai as a fresh developer in clean isolated environments, plus an independent agent run. Every fix below is verified against the actually-published SDK 1.17.5 / Maven Central / the live API — not doc-to-doc.

## Blockers fixed (all verified true before fixing)
- **Maven version wrong**: docs said `ai.bithuman:sdk:1.17.3`; Maven Central 404s it (latest is **1.17.1**). Fixed in `introduction`, `sdks/kotlin` (×2), `kotlin-android-hello`.
- **`pip install "bithuman[agent]"` doesn't exist** in 1.17.5 (pip warns, installs no livekit) → `pip install livekit-plugins-bithuman` (`sdks/python`).
- **False opencv claim**: docs said the SDK auto-pulls opencv — verified false (`import cv2` fails after `pip install bithuman`). Reworded (`sdks/python`, `ai-conversation`).
- **Example `requirements.txt` missing `opencv-python`** though `conversation.py`/`quickstart.py`/`microphone.py` call `cv2.imshow` → added.
- **Example/SDK API drift**: `conversation.py` + `microphone.py` called `runtime.run(idle_timeout=0.5)`; `run()` takes no args in 1.17.5 (`inspect.signature` confirmed) → `runtime.run()`.
- **`.imx`/`speech.wav` acquisition gap**: `python-hello` + `ai-conversation` code referenced bare filenames a newcomer can't produce → added how to get each (Explore / CLI-cached sample / `bithuman tts`), venv guidance, install the example `requirements.txt`, and a note that `hello.py` prints nothing by design.
- (From the prior commit on this branch) quickstart "Make it talk" trap + the fictional `/v2/credit-summaries` schema, aligned to the real API.

## Verified post-fix
Documented minimal loop renders **347 frames** on SDK 1.17.5; `requirements.txt` installs cleanly with opencv + livekit; all example scripts compile; `run()` signature matches.

## Honest limitation
`quickstart.py`/`conversation.py` are interactive GUI+audio programs — not fully drivable from a headless shell. The independent agent confirmed they render in a real desktop session; the SDK layer is verified here.