### PR TITLE
docs: bithuman 2.0.0 + 2.0.1 release notes + pip install path

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -10,11 +10,31 @@ Product-level changes only. Per-version notes: [Python SDK CHANGELOG](https://gi
 
 ## May 2026
 
+**Python SDK `bithuman` 2.0.1** (2026-05-24)
+- `AsyncBithuman.cleanup` is now `async` — `await b.cleanup()` works
+  (was raising `TypeError` and segfaulting at interpreter shutdown).
+- CLI error message polish: `bithuman pull <bad-slug>` and `bithuman
+  render` no longer reference renamed subcommands.
+- `essence-render --help` shows the correct prog name (was `bithuman`).
+
+**Python SDK `bithuman` 2.0.0** (2026-05-22) — bundled-CLI release
+- `pip install bithuman` now ships a `bithuman` console-script that
+  runs the full talk-to-your-avatar stack (Rust CLI + embedded
+  livekit-server + agent-worker brain + browser UI). One install,
+  one command, one URL — same Rust binary as the Homebrew CLI.
+- The runtime library API (`import bithuman`, `AsyncBithuman`,
+  `from bithuman import Avatar`) is unchanged — existing library
+  consumers keep working.
+- The legacy 1.x Python CLI is preserved as the `essence-render`
+  console-script.
+- Wheels: macOS arm64, Linux x86_64, Linux aarch64. Python 3.10+.
+- Quickstart: `pip install bithuman && bithuman run` — see
+  [Quickstart](/getting-started/quickstart) for the full flow.
+
 **v1.18.5** (2026-05-18)
 - Unified `bithuman`: one `pip install bithuman` = full prior `1.11.3` API + native engine, 100% backward-compatible (`==1.11.3` code runs unchanged).
 - Native engine: far faster cold load + lower memory than pure-Python, exact output parity. Loads fresh console `.imx` TAR exports natively.
 - Python 3.9–3.14 (Linux x86_64/ARM64, macOS Apple Silicon). Pin `>=1.18.5` (1.18.0–1.18.4 predate the unification; Windows/macOS-Intel stay on `==1.11.3`).
-
 
 **v1.17.x** (2026-05-14)
 - `bithuman avatar --openai` — workstation Realtime, browser-rendered avatar.

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -33,12 +33,25 @@ curl -fsSL https://github.com/bithuman-product/homebrew-bithuman/releases/latest
 
 # macOS via Homebrew (auto-pulls native deps)
 brew install bithuman-product/bithuman/bithuman
+
+# Or via pip — the 2.0 bundled wheel ships the same CLI inside the
+# Python package (no separate binary install). macOS arm64 + Linux
+# x86_64/aarch64; Python 3.10+.
+pip install bithuman
 ```
 
 ```bash
 export BITHUMAN_API_SECRET=your_api_secret
 bithuman doctor          # confirms host + key are good
 ```
+
+<Note>
+The `pip install bithuman` and Homebrew paths install the **same**
+Rust CLI binary (the pip path bundles it inside the wheel). The two
+install paths are interchangeable; pick whichever fits your
+environment. If you already use pip for backend services, sticking
+with pip lets you pin the avatar runtime + CLI together.
+</Note>
 
 ## 3. Make it talk
 

--- a/docs/sdks/python.mdx
+++ b/docs/sdks/python.mdx
@@ -15,8 +15,8 @@ native dependencies ship in the wheel.
 pip install bithuman --upgrade
 ```
 
-Python 3.9+ (3.9–3.14 wheels). Wheels: macOS arm64, Linux x86_64, Linux aarch64,
-Windows x86_64.
+Python 3.10+ (3.10–3.14 wheels). Wheels: macOS arm64, Linux x86_64,
+Linux aarch64, Windows x86_64.
 
 <Note>
 The SDK returns frames as numpy BGR arrays and needs **no** OpenCV
@@ -27,6 +27,32 @@ each example's `requirements.txt`.
 
 Auth: export `BITHUMAN_API_SECRET`. Get a secret at
 [Developer → API Keys](https://www.bithuman.ai/#developer).
+
+## 2.0 — `bithuman` is also a CLI
+
+Since 2.0, `pip install bithuman` also installs a `bithuman`
+console-script that spawns the **entire avatar stack** — embedded
+livekit-server, agent-worker brain, and browser UI — from one
+command. Same Rust binary as the [Homebrew CLI](/getting-started/cli);
+no extra install.
+
+```bash
+pip install bithuman
+export BITHUMAN_API_SECRET=... OPENAI_API_KEY=...
+bithuman run                                       # http://127.0.0.1:8088/<code>
+bithuman render avatar.imx -a speech.wav -o out.mp4   # offline render (Linux)
+bithuman info  avatar.imx                              # inspect an .imx
+bithuman pull  nova                                    # download a showcase avatar
+bithuman list                                          # browse showcase
+```
+
+The runtime library API below (`AsyncBithuman`, `from bithuman import
+Avatar`, …) is **unchanged** — existing library consumers keep
+working without code changes. The CLI is additive.
+
+The legacy 1.x Python CLI is preserved as the `essence-render`
+console-script (same binary as before; only the entry-script name
+changed).
 
 ## Streaming loop
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 All notable changes to the `bithuman` package are documented here.
 
+## [2.0.1] - 2026-05-24
+
+### Fixed
+- **`await b.cleanup()` on `AsyncBithuman` works.** Was raising
+  `TypeError: object NoneType can't be used in 'await' expression`
+  (the inherited parent method was sync), then segfaulting at
+  interpreter shutdown because the runtime never released. The async
+  override proxies to `stop()`; `__del__` overridden to bypass the
+  async cleanup and call the parent's sync release directly via MRO.
+- **`bithuman pull <bad-slug>` error message** no longer references
+  `bithuman models list`; says `bithuman list` (matches the actual
+  subcommand surface).
+- **`bithuman render` errors** no longer say `bithuman generate`
+  (leftover from a subcommand rename).
+- **`essence-render --help`** shows `usage: essence-render` (the
+  argparse `prog` was hardcoded to `bithuman`).
+
+## [2.0.0] - 2026-05-22
+
+### Added
+- **Bundled CLI.** `pip install bithuman` now ships a `bithuman`
+  console-script that runs the full talk-to-your-avatar stack — the
+  same Rust binary as the [Homebrew CLI](https://docs.bithuman.ai/getting-started/cli),
+  plus an embedded `livekit-server` child, plus an embedded
+  agent-worker brain (livekit-agents + OpenAI Realtime), plus a
+  static browser UI. One install, one command (`bithuman run`),
+  one URL.
+- **Subcommands**: `run` (live avatar), `render` (offline MP4 —
+  Linux only currently), `info` (inspect `.imx`), `pull` (showcase
+  fixture download), `list` (browse showcase). Run `bithuman --help`
+  for the surface.
+
+### Changed
+- **`bithuman` console-script semantics.** Pre-2.0 the `bithuman`
+  entry-script ran the legacy Python CLI (`bithuman pack`,
+  `bithuman generate`, …). It now execs the Rust binary. The legacy
+  Python CLI is preserved under the **`essence-render`**
+  entry-script (same code, different name). Scripts that called
+  `bithuman pack …` need to retarget to `essence-render pack …`.
+- **Python 3.10 minimum.** Was 3.9. The embedded brain
+  (`livekit-agents 1.4+` + `livekit-plugins-bithuman 1.4+`) requires
+  Python 3.10; pip will surface a clean "no matching wheel" error
+  on 3.9 instead of installing a wheel that fails at runtime.
+- **Wheel size:** ~50 MB (macOS arm64) / ~71 MB (Linux x86_64) /
+  ~70 MB (Linux aarch64). Was ~14 MB pre-2.0 (runtime library
+  only). The bundled Rust binary (~76 MB) + `livekit-server` (~44
+  MB) + vendored dep closure (~30 MB) account for the bulk.
+
+### Compat
+- The library API (`import bithuman`, `from bithuman import Avatar /
+  AsyncBithuman / Runtime / Fixture`, `bithuman.engine.*`, …) is
+  **unchanged**. Existing library consumers work without code edits.
+- `livekit-plugins-bithuman` is vendored under
+  `livekit/plugins/bithuman/` (PEP-420 namespace package) — same
+  import path. Installing a separate `livekit-plugins-bithuman`
+  package alongside `bithuman==2.x` is incompatible (the upstream
+  plugin pins `bithuman<1.12`).
+
 ## [1.18.5] - 2026-05-18
 
 ### Added


### PR DESCRIPTION
## Summary

Documents the 2.0 bundled-CLI release + 2.0.1 patch on docs.bithuman.ai.

- **changelog.mdx** — top-of-list entries for both releases.
- **sdks/python.mdx** — new "2.0 — `bithuman` is also a CLI" section
  noting that `pip install bithuman` now ships the same Rust CLI as
  Homebrew. Python floor bumped from 3.9 → 3.10 (matches the actual
  wheel matrix — bundled brain deps require 3.10+).
- **getting-started/quickstart.mdx** — `pip install bithuman` added
  as a third install path next to brew + curl|sh, with a note that
  all three install the same Rust binary.
- **python/CHANGELOG.md** — full 2.0.0 + 2.0.1 entries including
  breaking changes (console-script semantics + 3.10 floor).

## Live releases referenced
- https://pypi.org/project/bithuman/2.0.0/
- https://pypi.org/project/bithuman/2.0.1/

## Test plan
- [ ] `cd docs && npx mintlify@latest dev` — confirm no build errors
- [ ] visual diff of changelog page (new entries land above v1.17.x)
- [ ] visual diff of quickstart (3-install-path layout reads cleanly)