### PR TITLE
docs: surface 2.0 bundled CLI in top-level README + python/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,19 +69,28 @@ https://github.com/bithuman-product/bithuman-sdk-public.git
 
 Requires Apple Silicon M3 or newer. See [swift/README.md](swift/README.md) for details.
 
-### CLI (Mac, no code needed)
+### CLI — talk to an avatar in 2 minutes
+
+Two install paths, same Rust binary:
 
 ```bash
-# Universal installer (macOS + Linux)
-curl -fsSL https://github.com/bithuman-product/homebrew-bithuman/releases/latest/download/install.sh | sh
-# Or macOS Homebrew
-brew install bithuman-product/bithuman/bithuman
+# Path A: via pip (since 2.0, the wheel ships the bundled CLI)
+pip install bithuman
 
-bithuman avatar    # browser-served avatar at http://127.0.0.1:8080
-bithuman voice     # spoken conversation in the terminal
+# Path B: via Homebrew / curl (no Python needed)
+curl -fsSL https://github.com/bithuman-product/homebrew-bithuman/releases/latest/download/install.sh | sh
+brew install bithuman-product/bithuman/bithuman      # alternative
 ```
 
-100% on-device — runs locally on Apple Silicon, no API key needed for the audio-only mode.
+Either way:
+
+```bash
+export BITHUMAN_API_SECRET=...   OPENAI_API_KEY=...
+bithuman run                                          # auto-downloads a demo avatar
+# → http://127.0.0.1:8088/<code> — open in browser, click mic, talk
+```
+
+`bithuman run` is the full talk-to-your-avatar stack — embedded livekit-server + agent-worker brain + browser UI — from one command. For offline rendering and other modes, see [docs.bithuman.ai/getting-started/cli](https://docs.bithuman.ai/getting-started/cli).
 
 ## Quick start (Python)
 

--- a/python/README.md
+++ b/python/README.md
@@ -33,7 +33,7 @@ Architecture deep dive + production patterns at [docs.bithuman.ai](https://docs.
 pip install bithuman --upgrade
 ```
 
-Pre-built wheels for Python 3.9 – 3.14 on Linux x86_64 + ARM64, macOS Intel + Apple Silicon, Windows x86_64. No compile step.
+Pre-built wheels for Python 3.10 – 3.14 on Linux x86_64 + aarch64 and macOS Apple Silicon. (macOS Intel + Windows ship via a separate per-tag CI run; Python 3.9 dropped in 2.0 because the bundled brain requires 3.10.)
 
 For LiveKit Agent integration (voice agents with faces over WebRTC):
 
@@ -41,16 +41,36 @@ For LiveKit Agent integration (voice agents with faces over WebRTC):
 pip install bithuman[agent]
 ```
 
+## Two ways to use the package
+
+Since 2.0, `pip install bithuman` gives you **both** a Python library AND a `bithuman` CLI binary — same Rust binary the Homebrew install ships, just bundled into the wheel.
+
+### The talk-to-your-avatar CLI (2.0+)
+
+```bash
+pip install bithuman
+export BITHUMAN_API_SECRET=...   OPENAI_API_KEY=...
+bithuman run        # auto-downloads demo avatar → URL → browser → talk
+```
+
+`bithuman run` brings up the entire stack (embedded livekit-server + agent-worker brain + browser UI) from one command. The legacy 1.x Python CLI (`bithuman pack` / `generate` / `stream` / …) is preserved as the `essence-render` console-script.
+
+### The Python library (1.x API preserved)
+
+For backend services / batch jobs / custom integrations, the runtime API below is unchanged from 1.x — code pinned to `bithuman==1.11.3` runs on 2.0.1 without edits.
+
 ## Quick start — Essence (cross-platform, default)
 
 Grab an `.imx` from your [bitHuman dashboard](https://www.bithuman.ai/#explore) (⋮ → Download), export your API secret, then:
 
-### CLI
+### Offline render via CLI
 
 ```bash
 export BITHUMAN_API_SECRET=your_secret
-bithuman generate avatar.imx --audio speech.wav --output demo.mp4
+bithuman render avatar.imx --audio speech.wav --output demo.mp4   # Linux
 ```
+
+(Offline render on macOS routes via Apple's AVAssetWriter — planned follow-up; meanwhile use the Linux build or the Python library below.)
 
 Don't have a WAV to test with? Grab the 13-second sample bundled in the examples repo:
 


### PR DESCRIPTION
## Summary

Promotes `pip install bithuman && bithuman run` — the headline 2.0
talk-to-your-avatar path — to the top-level READMEs alongside the
existing brew/curl install. The bundled-CLI wording was already in
docs/changelog.mdx + docs/sdks/python.mdx + docs/getting-started/quickstart.mdx
(PR #14); this brings the GitHub-landing-page READMEs in line.

## Surface delta

- **README.md** — CLI section is now two install paths (pip OR brew/curl),
  same Rust binary; one headline `bithuman run` command.
- **python/README.md** — new "Two ways to use the package" block
  explains the 2.0 redefinition (`pip install bithuman` = library +
  CLI). Python floor bumped 3.9 → 3.10 (matches actual wheel matrix).
  `bithuman generate` → `bithuman render` in the offline-MP4 example.

## Test plan

- [x] Verbatim audit reproducible from each install path's first
  command — both produce a working 2.0.1 install on this M5
- [x] Cross-link `docs.bithuman.ai/getting-started/cli` for the full
  flag surface — unchanged