### PR TITLE
docs: bithuman[local] + 2.0/2.1 comprehensive pass

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -10,6 +10,41 @@ Product-level changes only. Per-version notes: [Python SDK CHANGELOG](https://gi
 
 ## May 2026
 
+**Python SDK `bithuman` 2.2.0** (2026-05-24) — `bithuman[local]` extra
+- New `pip install 'bithuman[local]'` extra adds a **fully on-device
+  conversation brain** to `bithuman run`. Flip it on with
+  `BITHUMAN_LOCAL=1`; no API key required, no outbound network.
+- Stack: `whisper.cpp` (STT) + `llama.cpp` (LLM, default Qwen 2.5
+  0.5B-Instruct Q4_K_M) + Supertonic 3 (TTS, 31 languages, voice M1
+  default) + Silero VAD. All in-process — no Ollama or other server.
+- All three backends have first-party iOS + Android C++ cores, so the
+  same `.gguf` / `.bin` / `.onnx` model files are reusable when porting
+  to mobile.
+- New plugins live in `livekit.plugins.bithuman.{WhisperSTT, LlamaCppLLM,
+  SupertonicTTS}` alongside `AvatarSession`. The avatar-only install
+  path is unchanged (heavy deps are lazy-imported).
+- Tuning via env vars: `BITHUMAN_LOCAL_WHISPER`, `BITHUMAN_LOCAL_LLM`,
+  `BITHUMAN_LOCAL_LLM_FILE`, `BITHUMAN_LOCAL_VOICE`, `BITHUMAN_LOCAL_LANG`,
+  `BITHUMAN_INSTRUCTIONS`. See [Python SDK · Fully on-device](/sdks/python#fully-on-device--bithumanlocal-22).
+- Footprint: ~860 MB on disk (auto-downloaded from HuggingFace on first
+  run), ~1.5 GB RAM, ~717 ms warm load, ~1.4 s warm end-to-end on
+  Apple Silicon.
+- Cloud path (`BITHUMAN_LOCAL` unset, `OPENAI_API_KEY` set) is
+  byte-for-byte unchanged.
+
+**Python SDK `bithuman` 2.1.0** (2026-05-24) — figure → avatar
+- Retired legacy "figure" terminology. CLI flag `--figures-root` is now
+  `--avatars-root` (old name kept as a deprecated alias). Default cache
+  moved from `~/.cache/bithuman/figures` to `~/.cache/bithuman/avatars`.
+- No runtime behavior change; alignment with the public-facing "avatar"
+  product term.
+
+**Python SDK `bithuman` 2.0.2** (2026-05-24) — graceful drain
+- `bithuman run` now cancels active sessions and waits ≤2 s for
+  libessence/HDF5 teardown before the process unwinds. Eliminates the
+  `H5F.c: decrementing file ID failed` + exit 134 SIGABRT on Ctrl-C /
+  LaunchDaemon stop. Required for production-style supervisors.
+
 **Python SDK `bithuman` 2.0.1** (2026-05-24)
 - `AsyncBithuman.cleanup` is now `async` — `await b.cleanup()` works
   (was raising `TypeError` and segfaulting at interpreter shutdown).

--- a/docs/sdks/python.mdx
+++ b/docs/sdks/python.mdx
@@ -54,6 +54,50 @@ The legacy 1.x Python CLI is preserved as the `essence-render`
 console-script (same binary as before; only the entry-script name
 changed).
 
+## Fully on-device — `bithuman[local]` (2.2+)
+
+For private, no-cloud operation, install the `[local]` extra and set
+`BITHUMAN_LOCAL=1`. The conversation brain swaps from OpenAI Realtime
+to an entirely in-process stack — no API key, no outbound network.
+
+```bash
+pip install 'bithuman[local]'
+export BITHUMAN_API_KEY=...
+BITHUMAN_LOCAL=1 bithuman run ~/.cache/bithuman/models/sample-avatar.imx
+# → open the printed http://127.0.0.1:8088/<code> URL in a browser
+```
+
+| Slot | Backend (mobile-portable C++ core) | Default model | Disk | RAM |
+| ---- | ---------------------------------- | ------------- | ---- | --- |
+| STT  | `pywhispercpp` → whisper.cpp        | `tiny.en`     | 77 MB  | ~150 MB |
+| LLM  | `llama-cpp-python` → llama.cpp      | Qwen 2.5 0.5B-Instruct Q4_K_M | 400 MB | ~600 MB |
+| TTS  | `supertonic` → ONNX Runtime         | Supertonic 3 (31 languages, voice M1) | 380 MB | ~600 MB |
+| VAD  | `livekit-plugins-silero`            | Silero        | 5 MB   | ~50 MB  |
+
+Total ~860 MB on disk, ~1.5 GB RAM, ~717 ms warm load, ~1.4 s warm
+end-to-end (STT + LLM + TTS) on Apple Silicon. First run downloads the
+models from HuggingFace into `~/.cache/{huggingface,supertonic}` — ~90
+seconds once.
+
+All three local backends have first-party iOS and Android C++ builds, so
+the same `.gguf` / `.bin` / `.onnx` model files port straight to mobile
+when those bindings ship.
+
+### Tuning
+
+| Env var | Default | What |
+| ------- | ------- | ---- |
+| `BITHUMAN_LOCAL` | _unset_ | `=1` flips the brain to the local stack. |
+| `BITHUMAN_LOCAL_WHISPER` | `tiny.en` | whisper.cpp size: `tiny.en` / `base.en` / `small` / `large-v3-turbo`. |
+| `BITHUMAN_LOCAL_LLM` | `Qwen/Qwen2.5-0.5B-Instruct-GGUF` | HuggingFace repo of a GGUF LLM. |
+| `BITHUMAN_LOCAL_LLM_FILE` | `qwen2.5-0.5b-instruct-q4_k_m.gguf` | GGUF file within the repo. |
+| `BITHUMAN_LOCAL_VOICE` | `M1` | Supertonic voice preset (`M1`–`M5` / `F1`–`F5`). |
+| `BITHUMAN_LOCAL_LANG` | `en` | Supertonic language (`en`, `ko`, `ja`, `es`, `de`, … — 31 total). |
+| `BITHUMAN_INSTRUCTIONS` | _short default_ | Override the system prompt. |
+
+The cloud path (`bithuman run` with `OPENAI_API_KEY` set, `BITHUMAN_LOCAL`
+unset) is unchanged.
+
 ## Streaming loop
 
 `AsyncBithuman` is the runtime — one instance per avatar session.


### PR DESCRIPTION
## Summary

- New "Fully on-device — \`bithuman[local]\` (2.2+)" section on the Python SDK page documenting the on-device brain (whisper.cpp + llama.cpp + Supertonic), env-var tuning, footprint, mobile-portability story
- Back-filled changelog entries for **2.0.2** (graceful drain), **2.1.0** (figure → avatar), and the new **2.2.0** (\`[local]\` extra)
- Earlier commit on this branch (\`0ec0cd9\`): README sync that surfaces the \`pip install bithuman\` → \`bithuman run\` path on the top-level + Python READMEs

Source change shipped in \`bithuman-sdk@fa0af33\`.

## Test plan

- [ ] \`cd docs && npx mintlify@latest dev\` — renders without build errors
- [ ] \`/sdks/python\` — the new "Fully on-device" section is in-line and the env-var table reads correctly
- [ ] \`/changelog\` — 2.2.0, 2.1.0, 2.0.2 entries land at the top of the May 2026 block