### PR TITLE
docs: 2.2.1 shipped (phantom 2.2.0 → 2.2.1)

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -10,7 +10,13 @@ Product-level changes only. Per-version notes: [Python SDK CHANGELOG](https://gi
 
 ## May 2026
 
-**Python SDK `bithuman` 2.2.0** (2026-05-24) — `bithuman[local]` extra
+**Python SDK `bithuman` 2.2.1** (2026-05-25) — `bithuman[local]` extra
+- (Note: 2.2.0 was tagged the day before but never published — PyPI
+  rejected uploads with bare `400 Bad Request`. 2.2.1 has identical
+  source content + a verbose-twine workflow tweak that surfaced the
+  real cause: the `bithuman` project had reached its 10 GB PyPI
+  storage cap. Deleting 6 superseded releases freed ~8.6 GB; ship
+  unblocked.)
 - New `pip install 'bithuman[local]'` extra adds a **fully on-device
   conversation brain** to `bithuman run`. Flip it on with
   `BITHUMAN_LOCAL=1`; no API key required, no outbound network.

--- a/docs/sdks/python.mdx
+++ b/docs/sdks/python.mdx
@@ -12,7 +12,7 @@ native dependencies ship in the wheel.
 ## Install
 
 ```bash
-pip install 'bithuman==2.1.1'
+pip install 'bithuman==2.2.1'
 ```
 
 **Python 3.10–3.14** supported. Platforms: macOS arm64, Linux


### PR DESCRIPTION
## Summary

- Bump install pin on \`docs/sdks/python.mdx\` from \`bithuman==2.1.1\` to \`bithuman==2.2.1\`
- Rename changelog 2.2.0 entry to 2.2.1; add a one-paragraph note explaining why 2.2.0 was a phantom (PyPI \`bithuman\` project hit 10 GB storage cap, blocking all uploads; freed by deleting 6 superseded releases, content reshipped as 2.2.1)

## Verification

\`pip install 'bithuman[local]==2.2.1'\` in a clean venv:
- ✓ resolves cleanly
- ✓ \`livekit.plugins.bithuman.{WhisperSTT, LlamaCppLLM, SupertonicTTS}\` all import
- ✓ \`livekit.plugins.bithuman.AvatarSession\` still importable

## Test plan

- [ ] \`cd docs && npx mintlify@latest dev\` — renders clean
- [ ] \`/sdks/python\` install snippet shows 2.2.1
- [ ] \`/changelog\` 2.2.1 entry reads correctly