### PR TITLE
docs: bump pin 2.2.1 → 2.2.2 (Linux CLI tarballs restored)

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -10,6 +10,17 @@ Product-level changes only. Per-version notes: [Python SDK CHANGELOG](https://gi
 
 ## May 2026
 
+**Python SDK `bithuman` 2.2.2** (2026-05-25) — Linux CLI tarballs restored
+- CI-only cleanup release; no API / runtime changes. Same Python wheel
+  content as 2.2.1.
+- Linux CLI tarballs (`bithuman-x86_64-unknown-linux-gnu.tar.gz` and
+  `bithuman-aarch64-unknown-linux-gnu.tar.gz`) ship on the GitHub
+  Release again — they had been missing since 2.0.1 because of two
+  container-build blockers, both now fixed in `main`.
+- Pin `bithuman==2.2.2` if you want `pip install` AND the standalone
+  Linux CLI binary from the same tag; `==2.2.1` is fine for wheel-only
+  consumers.
+
 **Python SDK `bithuman` 2.2.1** (2026-05-25) — `bithuman[local]` extra
 - (Note: 2.2.0 was tagged the day before but never published — PyPI
   rejected uploads with bare `400 Bad Request`. 2.2.1 has identical

--- a/docs/sdks/python.mdx
+++ b/docs/sdks/python.mdx
@@ -12,7 +12,7 @@ native dependencies ship in the wheel.
 ## Install
 
 ```bash
-pip install 'bithuman==2.2.1'
+pip install 'bithuman==2.2.2'
 ```
 
 **Python 3.10–3.14** supported. Platforms: macOS arm64, Linux


### PR DESCRIPTION
## Summary

- python.mdx install pin 2.2.1 → 2.2.2
- changelog.mdx 2.2.2 entry explaining the CI-only cleanup release + Linux CLI tarball restoration

Source change: bithuman-sdk@3b000b8 + libessence-v2.2.2 tag (CI run 26408254485 succeeded; 21/27 jobs success, 0 failures, 5 macOS-x86_64 stragglers — bonus wheels, non-blocking).

## Test plan

- [ ] \`/sdks/python\` install snippet shows 2.2.2
- [ ] \`/changelog\` 2.2.2 entry reads above 2.2.1