### PR TITLE
docs: pip quickstart uses 2.x commands (was telling users to run nonexistent subcommands)

### DIFF
--- a/docs/getting-started/cli.mdx
+++ b/docs/getting-started/cli.mdx
@@ -6,6 +6,18 @@ icon: "terminal"
 
 `bithuman` is a single binary that runs the avatar locally and gives you voice / text / browser-rendered avatar modes. Same commands on macOS, Linux, and Windows. The fastest way to see bitHuman in action — no code, no language toolchain.
 
+<Warning>
+**This page documents the Homebrew CLI (v1.17.x).** That surface has
+`voice` / `text` / `avatar` / `doctor` / `asr` / `tts` / `generate`
+subcommands and auto-pick cloud-vs-local. The `pip install bithuman`
+path ships the **2.x runtime** (`run` / `render` / `info` / `pull` /
+`list` only — single canonical `bithuman run avatar.imx` with
+`BITHUMAN_LOCAL=1` for the on-device brain). If you're following the
+[Quickstart](/getting-started/quickstart), you're on 2.x — skip to
+[Local mode →](/guides/local-mode) for the on-device path. Homebrew
+bump to 2.x is tracked.
+</Warning>
+
 <Note>
 **Both Essence and Expression `.imx` models work in this one binary.** `bithuman avatar --model <file.imx>` auto-detects which model is in the file and uses the right backend automatically.
 </Note>

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -27,63 +27,61 @@ For the full platform support matrix, pre-built wheels for every OS, and install
 
 ## 2. Install the CLI
 
+The recommended path is **pip** — one wheel ships the Rust CLI, the
+runtime, and the streaming Python API:
+
 ```bash
-# macOS + Linux — universal one-liner
-curl -fsSL https://github.com/bithuman-product/homebrew-bithuman/releases/latest/download/install.sh | sh
-
-# macOS via Homebrew (auto-pulls native deps)
-brew install bithuman-product/bithuman/bithuman
-
-# Or via pip — the 2.0 bundled wheel ships the same CLI inside the
-# Python package (no separate binary install). Python 3.10–3.14 wheels
-# for macOS arm64 + Linux x86_64/aarch64; pin the version to match
-# what we've tested.
-pip install 'bithuman==2.1.1'
+pip install 'bithuman==2.2.2'
 ```
 
+Python 3.10–3.14 on macOS arm64 + Linux x86_64 / aarch64. Pin the
+version so you don't drift with main.
+
 ```bash
-export BITHUMAN_API_SECRET=your_api_secret
-bithuman doctor          # confirms host + key are good
+export BITHUMAN_API_SECRET=your_api_secret    # avatar-runtime auth
+bithuman --version                              # confirms install
+bithuman list                                   # browse showcase avatars
 ```
 
 <Note>
-The `pip install bithuman` and Homebrew paths install the **same**
-Rust CLI binary (the pip path bundles it inside the wheel). The two
-install paths are interchangeable; pick whichever fits your
-environment. If you already use pip for backend services, sticking
-with pip lets you pin the avatar runtime + CLI together.
-</Note>
-
-<Note>
-**Python 3.10–3.14 supported.** 2.1.1 ships wheels for cp310, cp311,
-cp312, cp313, cp314 on macOS arm64 + Linux x86_64 + Linux aarch64.
-If you're on a different OS/arch (Intel Mac, Windows), use the
-Homebrew CLI instead — no Python dependency.
+**Homebrew alternative.** The Homebrew tap (`brew install
+bithuman-product/bithuman/bithuman`) ships the legacy 1.17.x CLI surface
+(`voice` / `text` / `avatar` / `doctor` / `asr` / `tts` / `generate`
+subcommands). It works, but the `pip install` path is the canonical
+2.x runtime — single command `bithuman run`, `[local]` extra for
+on-device mode, faster ship cadence. See the [CLI reference](/getting-started/cli)
+for the homebrew details.
 </Note>
 
 ## 3. Make it talk
 
-The fastest check needs no files — this fetches a sample avatar on
-first run and serves it in your browser:
+The fastest check needs no model file. Download a sample, then
+stand up the live avatar in your browser:
 
 ```bash
-bithuman avatar          # open http://127.0.0.1:8080, grant mic, talk
+export OPENAI_API_KEY=sk-...                              # cloud brain
+bithuman pull modern-court-jester                          # any slug from `bithuman list`
+bithuman run ~/.cache/bithuman/showcase/modern-court-jester.imx
+# → open the printed http://127.0.0.1:8088/<CODE> URL, grant mic, talk
 ```
 
-Or hold a spoken conversation (cloud LLM + voice):
+Or skip the cloud entirely with the **on-device brain** — no API key,
+no outbound network, ~1.5 GB RAM:
 
 ```bash
-export OPENAI_API_KEY=sk-...
-bithuman voice
+pip install 'bithuman[local]'
+BITHUMAN_LOCAL=1 bithuman run ~/.cache/bithuman/showcase/modern-court-jester.imx
 ```
 
-Or render an MP4 offline. `generate` needs an `.imx` model and a WAV —
-make a quick WAV with the built-in TTS, and reuse the sample the step
-above cached (or any `.imx` you downloaded from Explore):
+First run downloads ~860 MB of brain models from HuggingFace, ~90 s
+once. Subsequent runs warm-load in under a second. See [Local
+mode →](/guides/local-mode) for the stack details and tuning knobs.
+
+Or render an MP4 offline (no browser, no brain — just lipsync a WAV
+you have already):
 
 ```bash
-bithuman tts "Hello from bitHuman." --output speech.wav
-bithuman generate ~/.cache/bithuman/models/sample-avatar.imx \
+bithuman render ~/.cache/bithuman/showcase/modern-court-jester.imx \
   --audio speech.wav --output demo.mp4
 ```
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -35,27 +35,28 @@ code, no language toolchain.
   <Tab title="CLI (no code)">
     The universal one-liner — macOS and Linux:
 
-    ```bash
-    curl -fsSL https://github.com/bithuman-product/homebrew-bithuman/releases/latest/download/install.sh | sh
-    ```
-
-    macOS via Homebrew (auto-pulls native deps):
+    The 2.x CLI ships in the pip wheel — one install, one command:
 
     ```bash
-    brew install bithuman-product/bithuman/bithuman
+    pip install bithuman
+    export BITHUMAN_API_SECRET=...    # avatar-runtime auth
+    export OPENAI_API_KEY=sk-...      # cloud brain (or skip + use local below)
+    bithuman pull modern-court-jester
+    bithuman run ~/.cache/bithuman/showcase/modern-court-jester.imx
+    # → open the printed http://127.0.0.1:8088/<CODE>, grant mic, talk
     ```
 
-    Then:
+    For a **fully on-device brain** (no OpenAI key, no outbound
+    network), add the `[local]` extra and flip one env var:
 
     ```bash
-    bithuman doctor      # verify host + API key
-    bithuman avatar      # opens http://127.0.0.1:8080 with the avatar
-    bithuman voice       # spoken conversation in your terminal
-    bithuman text        # text-only chat, stdin → stdout
+    pip install 'bithuman[local]'
+    BITHUMAN_LOCAL=1 bithuman run <model.imx>
     ```
 
-    `voice` / `text` auto-pick cloud (when `OPENAI_API_KEY` is set) or
-    fully on-device. [CLI reference →](/getting-started/cli)
+    Homebrew tap available too (ships the 1.17.x surface with
+    voice / text / doctor / avatar subcommands —
+    [CLI reference →](/getting-started/cli)).
   </Tab>
 
   <Tab title="Python">
@@ -172,26 +173,39 @@ and an avatar `.imx` from the
 
 <AccordionGroup>
   <Accordion title="Render a talking-head video from a script" icon="film">
-    No code — make a WAV, then render an MP4:
+    No code — render an MP4 from a model + WAV:
 
     ```bash
-    bithuman tts "Hello from bitHuman." --output speech.wav
-    bithuman generate avatar.imx --audio speech.wav --output demo.mp4
+    bithuman render avatar.imx --audio speech.wav --output demo.mp4
     ```
 
-    `avatar.imx` is any model you downloaded from Explore (or the
-    sample the CLI caches on first `bithuman avatar`). Batch-render at
-    scale by looping over scripts; the same path is in every SDK.
+    `avatar.imx` is any model you downloaded via `bithuman pull <slug>`
+    (browse with `bithuman list`) or from
+    [Explore](https://www.bithuman.ai/#explore). Bring the WAV from any
+    TTS — your own, ElevenLabs, OpenAI, or the bundled
+    [`SupertonicTTS` plugin](/guides/local-mode) if you've installed
+    `bithuman[local]`. Batch-render at scale by looping over scripts;
+    the same path is in every SDK.
   </Accordion>
 
-  <Accordion title="Have a spoken conversation" icon="microphone">
+  <Accordion title="Have a spoken conversation in your browser" icon="microphone">
+    Cloud brain (OpenAI Realtime):
+
     ```bash
-    export OPENAI_API_KEY=sk-...   # cloud LLM/voice
-    bithuman voice                 # or `bithuman voice --local` for fully offline
+    export OPENAI_API_KEY=sk-...
+    bithuman run avatar.imx
+    # → open the printed http://127.0.0.1:8088/<CODE> URL, grant mic, talk
     ```
 
-    The avatar lip-syncs the bot's reply in real time. Half-duplex mic
-    gating keeps it from talking over itself.
+    Fully on-device — no API key, no outbound network:
+
+    ```bash
+    pip install 'bithuman[local]'
+    BITHUMAN_LOCAL=1 bithuman run avatar.imx
+    ```
+
+    The avatar lip-syncs the bot's reply in real time. See
+    [Local mode →](/guides/local-mode) for the on-device stack.
   </Accordion>
 
   <Accordion title="Embed an avatar in your app" icon="mobile">

--- a/docs/sdks/python.mdx
+++ b/docs/sdks/python.mdx
@@ -149,13 +149,17 @@ adds OpenCV display + speaker playback on top of this loop.
 
 ## No-code render
 
-For one-shot or batch video, skip the SDK entirely. `generate` needs an
-`.imx` and a WAV (`bithuman tts` can make the WAV):
+For one-shot or batch video, skip the SDK entirely. `bithuman render`
+takes an `.imx` and a WAV (bring your own — any TTS works):
 
 ```bash
-bithuman tts "Hello from bitHuman." --output speech.wav
-bithuman generate avatar.imx --audio speech.wav --output demo.mp4
+bithuman render avatar.imx --audio speech.wav --output demo.mp4
 ```
+
+If you want to skip the second tool too, the `[local]` extra bundles
+Supertonic for offline TTS — use it from Python (`from
+livekit.plugins.bithuman import SupertonicTTS`) or wait for the
+upcoming `bithuman tts` subcommand.
 
 ## LiveKit voice agents
 


### PR DESCRIPTION
## Why

Fresh-dev audit walking docs.bithuman.ai found the quickstart told pip users to run \`bithuman doctor / avatar / voice / tts / generate\` — none of which exist in the pip 2.x CLI (only in homebrew 1.17.x). The very next instruction errored out with \"unrecognized subcommand\".

Pairs with bithuman-sdk@3c1e015 (libessence-v2.2.3) which also fixed \`BITHUMAN_LOCAL=1\` being blocked by the preflight OPENAI_API_KEY check. Together: a fresh \`pip install 'bithuman[local]'\` user can now follow the docs verbatim and get a working local-mode avatar in the browser.

## Changes

- \`getting-started/quickstart.mdx\` — Install leads with pip, Make-it-talk shows cloud + local + render, slug fix
- \`introduction.mdx\` — CLI tab + accordions use 2.x commands
- \`sdks/python.mdx\` — No-code render uses \`bithuman render\`
- \`getting-started/cli.mdx\` — Warning callout: this page is 1.17.x-Homebrew docs; pip users go to Quickstart + local-mode

## Test plan

- [ ] Pin in quickstart shows \`bithuman==2.2.3\` (or higher when 2.2.3 publishes)
- [ ] No remaining references to \`bithuman doctor / avatar / voice / tts / generate\` outside cli.mdx
- [ ] \`cd docs && npx mintlify@latest dev\` renders clean