### PR TITLE
docs: bump pin 2.2.2 → 2.2.5

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -31,7 +31,7 @@ The recommended path is **pip** — one wheel ships the Rust CLI, the
 runtime, and the streaming Python API:
 
 ```bash
-pip install 'bithuman==2.2.2'
+pip install 'bithuman==2.2.5'
 ```
 
 Python 3.10–3.14 on macOS arm64 + Linux x86_64 / aarch64. Pin the

--- a/docs/sdks/python.mdx
+++ b/docs/sdks/python.mdx
@@ -12,7 +12,7 @@ native dependencies ship in the wheel.
 ## Install
 
 ```bash
-pip install 'bithuman==2.2.2'
+pip install 'bithuman==2.2.5'
 ```
 
 **Python 3.10–3.14** supported. Platforms: macOS arm64, Linux


### PR DESCRIPTION
Sweeps quickstart + python.mdx to point at the latest published wheel. Contains the BITHUMAN_LOCAL bypass + bithuman doctor + wheel-version display fix.