### PR TITLE
docs(deployment): fix self-host image name + add --tmpfs / --env-file

### DIFF
--- a/docs/guides/deployment.mdx
+++ b/docs/guides/deployment.mdx
@@ -174,7 +174,7 @@ this when you need a different portrait per session. 2 credits/min.
 # it out of shell history and `ps aux`.
 docker run --gpus all -p 8089:8089 \
   -v bithuman-models:/data/models \
-  --tmpfs /tmp/bh-weights:size=8g,mode=0700 \
+  --tmpfs /tmp/bh-weights:size=12g,mode=0700 \
   --env-file ./bithuman.env \
   sgubithuman/expression-avatar:latest
 ```

--- a/docs/guides/deployment.mdx
+++ b/docs/guides/deployment.mdx
@@ -170,16 +170,37 @@ video — entirely on your GPU; no cloud calls during inference. Use
 this when you need a different portrait per session. 2 credits/min.
 
 ```bash
+# Put BITHUMAN_API_SECRET=... in ./bithuman.env (chmod 600) — keeps
+# it out of shell history and `ps aux`.
 docker run --gpus all -p 8089:8089 \
-  -e BITHUMAN_API_SECRET=$BITHUMAN_API_SECRET \
-  bithuman/expression-avatar:latest
+  -v bithuman-models:/data/models \
+  --tmpfs /tmp/bh-weights:size=8g,mode=0700 \
+  --env-file ./bithuman.env \
+  sgubithuman/expression-avatar:latest
 ```
 
 Then `POST /launch` with `{ livekit_url, livekit_token, room_name,
 avatar_image }` from your agent; the container joins the room and
 publishes video. Requires an NVIDIA GPU (≥ 8 GB VRAM), the NVIDIA
 Container Toolkit, Docker 24+. Weights (~5 GB) download on first run
-into a Docker volume.
+into the `bithuman-models` volume; subsequent runs skip the download.
+
+<Tip>
+**First-run startup takes ~2 minutes** (model download + decrypt + TRT
+engine warm). Poll `GET /ready` — it returns `200` when the worker is
+ready to accept `/launch` requests.
+</Tip>
+
+<Tip>
+**Why `--tmpfs`?** Model weights are AES-256-GCM encrypted at rest in
+the `bithuman-models` volume and decrypted at startup using a key
+fetched from `api.bithuman.ai` (gated by your `BITHUMAN_API_SECRET`).
+The `--tmpfs` flag keeps the *decrypted* copy in RAM only — without it
+the plaintext lands on the container's writable layer and can be read
+via `docker cp` or baked into a derived image via `docker commit`. The
+container starts either way; if `--tmpfs` is missing you'll see a loud
+`SECURITY:` warning in the startup logs.
+</Tip>
 
 <Tip>
 On Apple Silicon M3+ Expression runs natively — no Docker/NVIDIA.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -250,8 +250,10 @@ and an avatar `.imx` from the
   <Accordion title="Self-host Expression on your own GPU" icon="server">
     ```bash
     docker run --gpus all -p 8089:8089 \
-      -e BITHUMAN_API_SECRET=$BITHUMAN_API_SECRET \
-      bithuman/expression-avatar:latest
+      -v bithuman-models:/data/models \
+      --tmpfs /tmp/bh-weights:size=8g,mode=0700 \
+      --env-file ./bithuman.env \
+      sgubithuman/expression-avatar:latest
     ```
 
     Point a LiveKit agent at `http://localhost:8089/launch`.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -251,7 +251,7 @@ and an avatar `.imx` from the
     ```bash
     docker run --gpus all -p 8089:8089 \
       -v bithuman-models:/data/models \
-      --tmpfs /tmp/bh-weights:size=8g,mode=0700 \
+      --tmpfs /tmp/bh-weights:size=12g,mode=0700 \
       --env-file ./bithuman.env \
       sgubithuman/expression-avatar:latest
     ```


### PR DESCRIPTION
## Summary

Two issues surfaced while following the **Self-hosted GPU (Expression)** flow in https://docs.bithuman.ai/guides/deployment from a clean machine:

### 1. Doc'd image name doesn't exist (blocker for new users)

The docs say:
\`\`\`bash
docker run --gpus all -p 8089:8089 \\
  -e BITHUMAN_API_SECRET=\$BITHUMAN_API_SECRET \\
  bithuman/expression-avatar:latest          # ← does not exist
\`\`\`
\`docker pull bithuman/expression-avatar:latest\` returns \`{"message":"object not found"}\`. The actual published image is **\`sgubithuman/expression-avatar:latest\`**.

### 2. Decrypted weights bypass the at-rest encryption without \`--tmpfs\`

The runtime decrypts ~6 GB of plaintext model weights to \`/tmp/bh-weights\` for the container's full lifetime. \`/tmp\` inside the container is the regular overlay filesystem, not tmpfs — so the plaintext is readable via:
\`\`\`bash
docker cp <container>:/tmp/bh-weights/ ./   # extract plaintext, no API key needed
docker commit <container> stolen-image      # bake plaintext into derived image
\`\`\`

Companion runtime PR bithuman-product/platform#35 adds \`VOLUME ["/tmp/bh-weights"]\` to the Dockerfile, a \`SECURITY:\` startup warning when \`--tmpfs\` is missing, and a production-compose tmpfs default. Docs need to teach users the \`--tmpfs\` flag.

## Changes

- \`docs/guides/deployment.mdx\`: corrected image name; added \`-v\`, \`--tmpfs\`, and \`--env-file\` flags; new Tip blocks for the ~2 min prewarm wait and the \`--tmpfs\` threat model
- \`docs/introduction.mdx\`: same fixes to the accordion preview snippet

## Test plan

- [x] Followed the corrected docs end-to-end on an RTX 4070 Ti:
  - Missing secret → fail-fast at startup (no model touch)
  - Invalid secret → backend 401 (no decryption attempted)
  - Valid secret → \`/ready\` returns 200 in ~2 min; \`/benchmark\` returns 75.7 FPS; \`/test-frame\` returns a real 512x512 JPEG
- [x] Verified \`docker.io/sgubithuman/expression-avatar:latest\` pull works
- [ ] Reviewer: skim rendered Mintlify preview for the new Tip blocks