### PR TITLE
docs(deployment): bump tmpfs size 12g → 9g after legacy fp16 drop

### DIFF
--- a/docs/guides/deployment.mdx
+++ b/docs/guides/deployment.mdx
@@ -174,7 +174,7 @@ this when you need a different portrait per session. 2 credits/min.
 # it out of shell history and `ps aux`.
 docker run --gpus all -p 8089:8089 \
   -v bithuman-models:/data/models \
-  --tmpfs /tmp/bh-weights:size=12g,mode=0700 \
+  --tmpfs /tmp/bh-weights:size=9g,mode=0700 \
   --env-file ./bithuman.env \
   sgubithuman/expression-avatar:latest
 ```

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -257,7 +257,7 @@ and an avatar `.imx` from the
     ```bash
     docker run --gpus all -p 8089:8089 \
       -v bithuman-models:/data/models \
-      --tmpfs /tmp/bh-weights:size=12g,mode=0700 \
+      --tmpfs /tmp/bh-weights:size=9g,mode=0700 \
       --env-file ./bithuman.env \
       sgubithuman/expression-avatar:latest
     ```


### PR DESCRIPTION
## Summary

The Expression runtime no longer downloads or decrypts the legacy \`dit_lite_fp16.trt\` prebuilt (see bithuman-product/platform PR above) — actual decrypted weight set shrank from 11 GB to **7.5 GB**. A 9g \`--tmpfs\` gives 1.5 GB headroom while saving 3 GB of operator RAM.

## Changes

- \`docs/guides/deployment.mdx\`: \`size=12g\` → \`size=9g\`
- \`docs/introduction.mdx\`: same fix in the accordion preview snippet

## Test plan

- [x] Verified on RTX 4070 Ti with new \`--tmpfs ... size=9g\`: \`df /tmp/bh-weights\` shows 9G / 7.5G used / 1.4G avail; \`/ready\` 200 at 80s; \`/benchmark\` 75.7 FPS