### PR TITLE
refactor: single-source examples + expose Expression/Bithuman products + mirror

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,32 @@
+# CODEOWNERS — required reviewers for the public bithuman-sdk repo.
+#
+# GitHub uses the LAST matching pattern for a given path, so the more
+# specific rules below override the catch-all. Owners listed here are
+# auto-requested for review on any PR that touches the matching paths.
+#
+# NOTE: @bithuman-product/maintainers is the default owning team. Adjust
+# the team handles below to the actual GitHub teams once they exist; the
+# patterns are what matter for the public-surface gate.
+
+# ----------------------------------------------------------------------
+# Default: everything is owned by the maintainers team unless a more
+# specific rule below claims it.
+# ----------------------------------------------------------------------
+*                                       @bithuman-product/maintainers
+
+# ----------------------------------------------------------------------
+# Public SDK surface. The Swift package manifest and the Examples are the
+# contract end users build against; they must not silently drift from the
+# SDK surface, so the SDK team gates any change.
+# ----------------------------------------------------------------------
+/Package.swift                          @bithuman-product/sdk
+/Examples/                              @bithuman-product/sdk
+/docs/                                  @bithuman-product/sdk
+
+# ----------------------------------------------------------------------
+# Release + CI machinery and the repo guards. Changes to these gates need
+# maintainer sign-off so a guard can't be quietly weakened.
+# ----------------------------------------------------------------------
+/.github/                               @bithuman-product/maintainers
+/.github/workflows/                     @bithuman-product/maintainers
+/scripts/                               @bithuman-product/maintainers

--- a/.github/workflows/bump-docs.yml
+++ b/.github/workflows/bump-docs.yml
@@ -1,0 +1,190 @@
+# Auto-bump the docs version pin in THIS repo on every libessence-v*
+# release publish in the private bithuman-product/bithuman-sdk repo.
+#
+# WHERE THIS LIVES (changed 2026-05-29):
+#   This workflow now lives in the public repo (bithuman-sdk-public),
+#   making this repo the single source of truth for its own docs mirror.
+#   Because the bump happens IN this repo, the same-repo `GITHUB_TOKEN`
+#   has the `contents: write` + `pull-requests: write` it needs to push a
+#   branch and open the PR — no cross-repo PAT required on THIS side.
+#
+#   Previously this workflow lived in bithuman-sdk and checked this repo
+#   out via a MIRROR_RELEASE_PAT cross-repo token. It was disabled on
+#   2026-05-28 because MIRROR_RELEASE_PAT evaluated to empty on the
+#   private repo's runner context (`actions/checkout` errored with
+#   "Input required and not supplied: token"). Re-homing it here removes
+#   that failure mode for the manual/auto in-repo path.
+#
+# TRIGGERS:
+#   - workflow_dispatch: manual, with a `version` input (e.g. "2.3.0").
+#     Always available; use this for re-runs or one-off bumps.
+#   - repository_dispatch (event_type: libessence-release): fired by the
+#     private bithuman-sdk release flow on `release: published` for a
+#     libessence-v* tag. The DISPATCHING side (bithuman-sdk) must hold a
+#     MIRROR_RELEASE_PAT secret — a PAT (or fine-grained token) with
+#     `contents: write` + `actions: write` on THIS repo — to POST the
+#     repository_dispatch. See the "MIRROR_RELEASE_PAT" note below.
+#
+# MIRROR_RELEASE_PAT (still required, but only on the dispatching side):
+#   The private bithuman-sdk repo provisions MIRROR_RELEASE_PAT and uses
+#   it to send the repository_dispatch that fires this workflow, e.g.:
+#
+#       gh api repos/bithuman-product/bithuman-sdk-public/dispatches \
+#         -f event_type=libessence-release \
+#         -F client_payload[version]="${VERSION}"
+#
+#   provisioning checklist:
+#     1. Create a fine-grained PAT scoped to bithuman-sdk-public with
+#        Contents:RW + Actions:RW (no other repos, no other scopes).
+#     2. Add it as the `MIRROR_RELEASE_PAT` secret in bithuman-sdk.
+#     3. Verify it reads non-empty inside a workflow_dispatch dry-run on
+#        the dispatching repo before relying on the auto path.
+#   Until that PAT is provisioned + verified, use the `workflow_dispatch`
+#   path here (which needs no PAT).
+#
+# What the job does:
+#   1. Resolves the libessence version from the dispatch payload or input.
+#   2. Scans docs/ and python/README.md, derives the OLD version from the
+#      highest currently-pinned semver across those paths.
+#   3. Replaces every OLD -> NEW occurrence in those paths.
+#   4. Opens a PR (does NOT auto-merge — a human reviews the doc edits).
+#
+# Idempotent: if OLD == NEW the job exits before opening a PR. If a
+# bump-docs PR is already open against the same NEW version, the job
+# updates that branch via `git push --force-with-lease`.
+#
+# Workflow-injection-safe: version input is bound to env at job level,
+# validated by regex BEFORE any shell interpolation, then referenced as
+# $VERSION inside `run:` blocks. The sed pattern is built from the
+# env-validated OLD/NEW strings only.
+
+name: Bump docs version pin
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "libessence version to bump to (without the 'v' prefix, e.g. 2.3.0)"
+        required: true
+        type: string
+  repository_dispatch:
+    types: [libessence-release]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    name: Open docs version-bump PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      INPUT_VERSION: ${{ inputs.version }}
+      DISPATCH_VERSION: ${{ github.event.client_payload.version }}
+      DOCS_REPO: ${{ github.repository }}
+    steps:
+      - name: Resolve version
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_VERSION:-}" ]; then
+            VERSION="$INPUT_VERSION"
+          elif [ -n "${DISPATCH_VERSION:-}" ]; then
+            VERSION="$DISPATCH_VERSION"
+          else
+            echo "::error::no version supplied (neither workflow_dispatch input nor repository_dispatch payload)"
+            exit 1
+          fi
+          # Tolerate a leading "libessence-v" in case the dispatcher
+          # forwards the raw tag.
+          VERSION="${VERSION#libessence-v}"
+          VERSION="${VERSION#v}"
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([a-z0-9]+)?$ ]]; then
+            echo "::error::version '$VERSION' doesn't look like a semver tag"
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "resolved VERSION=$VERSION"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Derive OLD version from docs and rewrite
+        run: |
+          set -euo pipefail
+          # Scan docs/ + python/README.md for pinned semver of the form
+          # 2.x.y (and pre-release suffixes). Pick the highest as OLD —
+          # this tolerates a docs tree where most files already pin the
+          # current version and a few stragglers lag.
+          TARGETS=()
+          [ -d docs ] && TARGETS+=("docs")
+          [ -f python/README.md ] && TARGETS+=("python/README.md")
+          if [ ${#TARGETS[@]} -eq 0 ]; then
+            echo "::error::no docs/ or python/README.md found in $DOCS_REPO"
+            exit 1
+          fi
+          OLD=$(grep -rhoE '\b2\.[0-9]+\.[0-9]+([a-z0-9]+)?\b' "${TARGETS[@]}" \
+                  | sort -V | tail -n 1 || true)
+          if [ -z "$OLD" ]; then
+            echo "::error::no 2.x.y pin found in ${TARGETS[*]} — nothing to bump"
+            exit 1
+          fi
+          echo "OLD=$OLD"
+          echo "NEW=$VERSION"
+          if [ "$OLD" = "$VERSION" ]; then
+            echo "docs already at $VERSION — nothing to do"
+            echo "SKIP=1" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          # Word-boundary sed: anchor the version so 2.2.5 doesn't also
+          # match "2.2.50". GNU sed (\b) works on the ubuntu-latest runner.
+          OLD_ESC=$(printf '%s\n' "$OLD" | sed 's/\./\\./g')
+          find "${TARGETS[@]}" -type f \
+            \( -name '*.md' -o -name '*.mdx' -o -name '*.rst' -o -name '*.txt' -o -name '*.yml' -o -name '*.yaml' -o -name '*.json' -o -name '*.toml' \) \
+            -exec sed -i "s/\\b${OLD_ESC}\\b/${VERSION}/g" {} +
+          echo "OLD=$OLD" >> "$GITHUB_ENV"
+          echo "-- changed files --"
+          git status --short
+          echo "-- diff (first 200 lines) --"
+          git --no-pager diff | head -n 200
+
+      - name: Open PR
+        if: env.SKIP != '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "no changes after sed — nothing to do"
+            exit 0
+          fi
+          git config user.name  "bitHuman"
+          git config user.email "hello@bithuman.ai"
+          BRANCH="bump-docs/${VERSION}"
+          # Recreate the branch fresh each run so re-runs against the
+          # same version overwrite stale edits rather than diverge.
+          git checkout -B "$BRANCH"
+          git add -A
+          git commit -m "docs: bump pin ${OLD} -> ${VERSION} (auto via bithuman-sdk release publish)"
+          git push --force-with-lease origin "$BRANCH"
+          # Reuse an existing open PR for this branch if one's already
+          # there; otherwise open a new one. Do NOT auto-merge.
+          if gh pr view "$BRANCH" --repo "$DOCS_REPO" --json number >/dev/null 2>&1; then
+            echo "PR for $BRANCH already exists — branch force-pushed; PR will refresh"
+          else
+            cat > /tmp/pr_body.md <<EOF
+          Automated docs version bump triggered by libessence-v${VERSION} publish in bithuman-sdk.
+
+          Replaced every occurrence of \`${OLD}\` with \`${VERSION}\` across \`docs/\` and \`python/README.md\`.
+
+          Please review the diff before merging — sed is a blunt instrument and may catch unrelated \`${OLD}\` strings (e.g. in changelogs).
+          EOF
+            gh pr create \
+              --repo "$DOCS_REPO" \
+              --head "$BRANCH" \
+              --base main \
+              --title "docs: bump pin ${OLD} -> ${VERSION}" \
+              --body-file /tmp/pr_body.md
+          fi

--- a/Examples/swift/README.md
+++ b/Examples/swift/README.md
@@ -15,6 +15,29 @@ bitHumanKit is distributed as a SwiftPM binary package with zero transitive Swif
 
 Each example is a standalone SPM project. Clone, open in Xcode (or `swift run` from the terminal), and go.
 
+## Developer tools
+
+These are lower-level harnesses (benchmarks, A/B comparisons, a server daemon) carried over from the SDK's own development. They show how to consume the individual engine products directly.
+
+| Example | Consumes | What it shows |
+|---------|----------|---------------|
+| [hello-voice-chat/](hello-voice-chat/) | `bitHumanKit` | The smallest possible SPM executable embedding the SDK: `VoiceChat` + `VoiceChatConfig`, no avatar, no billing. |
+| [compare-dit/](compare-dit/) | `Expression` | Render a WAV → lip-synced MP4 to A/B fp16 vs int4 DiT quality. Targets the Layer-1 Expression engine directly. |
+| [compare-llm/](compare-llm/) | upstream MLX OSS | Load each on-device LLM (iOS vs macOS split) on a fixed prompt set. No bitHuman binary — same OSS path as `LLMClient`. |
+| [compare-tts/](compare-tts/) | `Voice` (private source) | Load Kokoro + Qwen3-TTS and synthesize a fixed utterance. **Requires the private bithuman-sdk sibling checkout** (see its README). |
+| [bench-essence/](bench-essence/) | `bitHumanKit` | Essence runtime perf + correctness bench. Full correctness path needs an internal test seam (see its README). |
+| [essence-server/](essence-server/) | `bitHumanKit` + LiveKit + Hummingbird | Native Swift LiveKit avatar service: hosts N runtimes behind HTTP `/launch`, republishes video + audio. |
+
+## SwiftPM products
+
+The published package exposes three library products. Most apps want the umbrella; the two engine products are for when you need one layer without the rest.
+
+| Product | `import` | What it is |
+|---------|----------|------------|
+| `bitHumanKit` | `import bitHumanKit` | Umbrella SDK — STT + LLM + TTS + both avatar engines. |
+| `Expression` | `import Expression` | Layer-1 avatar engine only (Wav2Vec2 → DiT → VAE → ANE). Home of the `Bithuman` actor, `Bithuman.Quality`, `AvatarConfig`. |
+| `Bithuman` | `import Bithuman` | Layer-1 Essence engine only (libessence; audio → BGR frames from an `.imx`). CPU-only, any Apple Silicon. |
+
 ## Supported models
 
 - **Expression** -- AI-generated facial animation from any face image, powered by the on-device Swift daemon.

--- a/Examples/swift/bench-essence/Package.swift
+++ b/Examples/swift/bench-essence/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+// BenchEssence — apples-to-apples Essence runtime perf + correctness
+// bench harness. Sibling of the Python bench_essence.py.
+//
+// NOTE ON THE DEPENDENCY: this harness calls the internal
+// `EssenceRuntime.generateFrameDetailedForBench` test seam (per-frame
+// `cluster_idx`), which is NOT part of the public `bitHumanKit` /
+// `Bithuman` API surface. Against the published binary it will fail to
+// compile at that call site. To run the full per-frame correctness path
+// you need an internal build of the framework that exposes the seam;
+// the public binary only surfaces the rendered frames via `frames()`.
+// See README.md.
+let package = Package(
+    name: "BenchEssence",
+    platforms: [
+        .macOS("26.0")
+    ],
+    dependencies: [
+        .package(name: "bithuman",
+                 url: "https://github.com/bithuman-product/bithuman-sdk-public.git",
+                 from: "0.8.1")
+    ],
+    targets: [
+        .executableTarget(
+            name: "BenchEssence",
+            dependencies: [
+                .product(name: "bitHumanKit", package: "bithuman")
+            ],
+            path: "Sources/BenchEssence",
+            swiftSettings: [.swiftLanguageMode(.v5)]
+        )
+    ]
+)

--- a/Examples/swift/bench-essence/README.md
+++ b/Examples/swift/bench-essence/README.md
@@ -1,0 +1,42 @@
+# BenchEssence
+
+Apples-to-apples Essence runtime perf + correctness bench harness. The
+Swift sibling of the Python `bench_essence.py`; both emit byte-identical
+CSV column names and `meta.json` keys so cross-binding parity can be
+diffed directly.
+
+## Run
+
+```bash
+cd Examples/swift/bench-essence
+swift run -c release BenchEssence \
+  --fixture path/to/avatar.imx \
+  --audio   path/to/16k_mono.wav \
+  --frames 300 --warmup 50 \
+  --output ./bench-out \
+  [--reference ./reference-frames]
+```
+
+Output:
+
+- `<output>/bench.csv` — one row per measured frame (wall_time_ms,
+  cluster_idx, frame_sha256, optional PSNR)
+- `<output>/meta.json` — summary metrics + host info + fixture sha256s
+
+## Important: internal test seam
+
+This harness calls `EssenceRuntime.generateFrameDetailedForBench`, an
+**internal test seam** that surfaces per-frame `cluster_idx`. That symbol
+is NOT part of the public `bitHumanKit` / `Bithuman` API — the published
+binary only exposes rendered frames via the `frames()` AsyncStream.
+
+As a result the full per-frame **correctness** path compiles only against
+an internal build of the framework that exposes the seam. The perf-only
+path (timings + RSS, no `cluster_idx`/PSNR) works against the public
+binary. See the source header for the metric definitions and warm-up
+protocol.
+
+## Requires
+
+- macOS 26+ (Tahoe), Apple Silicon
+- A `.imx` Essence model and a 16 kHz mono int16 WAV (no resampling)

--- a/Examples/swift/bench-essence/Sources/BenchEssence/main.swift
+++ b/Examples/swift/bench-essence/Sources/BenchEssence/main.swift
@@ -1,0 +1,1186 @@
+// BenchEssence — apples-to-apples Essence runtime perf + correctness
+// bench harness. Sibling of bithuman-python-sdk/tools/bench_essence.py.
+//
+// See docs/architecture/essence-port-plan.md Appendix B for the
+// metric definitions, warm-up protocol (50 discarded + 250 measured),
+// and CSV / meta.json schema. Both this binary and the Python sibling
+// MUST emit byte-identical column names + meta keys.
+//
+// Usage:
+//   swift run -c release bench-essence \
+//     --fixture path/to/avatar.imx \
+//     --audio   path/to/16k_mono.wav \
+//     --frames 300 --warmup 50 \
+//     --output ./bench-out \
+//     [--reference ./reference-frames]
+//
+// Output:
+//   <output>/bench.csv      one row per measured frame
+//   <output>/meta.json      summary metrics + host info + fixture sha256s
+//
+// The harness:
+//   1. Loads the .imx via Bithuman.createRuntime, asserts .essence.
+//   2. Loads the WAV (must already be 16 kHz mono int16 — resampling
+//      is out of scope; the fixture corpus pre-pins this).
+//   3. Times cold-start = wall from createRuntime() returning to first
+//      frame yielded.
+//   4. Drives audio through the runtime in 640-sample (40 ms) chunks,
+//      one per frame. Discards `warmup` frames, measures the next
+//      `frames - warmup`.
+//   5. Per measured frame: wall_time_ms, cluster_idx, frame_sha256,
+//      optional PSNR vs reference PNG.
+//   6. Sidecar 100 Hz RSS sampler (mach_task_basic_info::resident_size_max),
+//      max-aggregated.
+//   7. Optional `powermetrics --samplers cpu_power -i 100 -n 50`
+//      external invocation; reads back joules averaged over the run.
+//   8. Emits CSV + meta.json matching Appendix B's schema.
+
+import AVFoundation
+import bitHumanKit
+import CoreGraphics
+import CoreImage
+import CoreMedia
+import CoreVideo
+import CryptoKit
+import Darwin
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+import VideoToolbox
+
+// MARK: - Metallib bootstrap
+
+/// Symlink `mlx.metallib` next to the bench-essence binary at startup.
+///
+/// SwiftPM's release build doesn't compile MLX's `.metal` shaders into
+/// a `default.metallib` automatically, so MLX's `load_default_library`
+/// fails on first GPU op. The `Plugins/MLXMetallibBuilder/` build-tool
+/// plugin compiles the JIT kernel set into `mlx.metallib` and SwiftPM
+/// bundles it into the BenchEssence resource bundle (`Bundle.module`);
+/// MLX's loader only checks paths colocated with the binary. Symlink
+/// once at startup before any `Bithuman.createRuntime` call.
+// Metallib bootstrap disabled — moraga has Command Line Tools only
+// (no Metal compiler), and the Essence runtime is CPU-only (NEON +
+// Accelerate + vImage), so MLX's load_default_library is never called.
+private let _ensureMetalLibraryAtStartup: Void = { () }()
+
+// MARK: - CLI
+
+struct CLIArgs {
+    var fixture: URL?
+    var audio: URL?
+    var frames: Int = 300
+    var warmup: Int = 50
+    var output: URL?
+    var reference: URL?
+    var dryRun: Bool = false
+    /// When > 0, switch to multi-instance memory check mode: load the
+    /// fixture once, build N runtimes off it, drive a couple frames
+    /// through each, report peak RSS at every step. Validates the
+    /// shared-fixture path's per-instance memory delta.
+    var multiInstance: Int = 0
+    /// Frames per runtime in `--multi-instance` mode.
+    var multiInstanceFrames: Int = 25
+
+    static func parse() -> CLIArgs {
+        let raw = Array(CommandLine.arguments.dropFirst())
+        var args = CLIArgs()
+        var i = 0
+        while i < raw.count {
+            let a = raw[i]
+            func next() -> String? {
+                guard i + 1 < raw.count else { return nil }
+                i += 1
+                return raw[i]
+            }
+            switch a {
+            case "-h", "--help":
+                printUsage()
+                exit(0)
+            case "--fixture":
+                guard let v = next() else { fail("--fixture requires a value") }
+                args.fixture = URL(fileURLWithPath: v)
+            case "--audio":
+                guard let v = next() else { fail("--audio requires a value") }
+                args.audio = URL(fileURLWithPath: v)
+            case "--frames":
+                guard let v = next(), let n = Int(v), n > 0 else {
+                    fail("--frames requires a positive integer")
+                }
+                args.frames = n
+            case "--warmup":
+                guard let v = next(), let n = Int(v), n >= 0 else {
+                    fail("--warmup requires a non-negative integer")
+                }
+                args.warmup = n
+            case "--output":
+                guard let v = next() else { fail("--output requires a value") }
+                args.output = URL(fileURLWithPath: v)
+            case "--reference":
+                guard let v = next() else { fail("--reference requires a value") }
+                args.reference = URL(fileURLWithPath: v)
+            case "--dry-run":
+                args.dryRun = true
+            case "--multi-instance":
+                guard let v = next(), let n = Int(v), n > 0 else {
+                    fail("--multi-instance requires a positive integer")
+                }
+                args.multiInstance = n
+            case "--multi-instance-frames":
+                guard let v = next(), let n = Int(v), n > 0 else {
+                    fail("--multi-instance-frames requires a positive integer")
+                }
+                args.multiInstanceFrames = n
+            default:
+                fail("unknown arg: \(a)")
+            }
+            i += 1
+        }
+        return args
+    }
+}
+
+func printUsage() {
+    let usage = """
+    bench-essence — apples-to-apples Essence runtime perf + correctness
+    bench harness. See docs/architecture/essence-port-plan.md Appendix B.
+
+    Usage:
+      bench-essence --fixture <imx> --audio <wav> --output <dir> \\
+        [--frames N=300] [--warmup N=50] [--reference <dir>] [--dry-run]
+
+    Required:
+      --fixture <path>   .imx Essence avatar bundle (pinned by sha256
+                         in the fixture manifest).
+      --audio   <path>   WAV file. Must be 16 kHz mono int16; resampling
+                         is OUT OF SCOPE — fixtures pre-pin this.
+      --output  <dir>    Output directory. Will be created. bench.csv
+                         + meta.json are written here.
+
+    Optional:
+      --frames    <N>    Total frames to generate. Default 300.
+      --warmup    <N>    First N frames discarded as cold/JIT warm.
+                         Default 50. Measured = frames - warmup.
+      --reference <dir>  Directory of NNNNN.png reference frames from
+                         the OTHER SDK. If passed, PSNR per frame is
+                         computed and recorded.
+      --dry-run          Skip runtime construction; exercise the CSV
+                         writer + RSS sampler with synthetic data.
+                         Used by smoke tests.
+
+    Apples-to-apples invariants (Appendix B, NON-NEGOTIABLE):
+      - Same machine. Same .imx (sha256). Same WAV (sha256).
+      - Discard first 50 frames; measure next 250. Default --frames=300.
+      - Per-frame timing measured at SDK call boundary (no audio I/O).
+      - peak_rss_mb sampled @100 Hz via mach_task_basic_info; the Python
+        sibling uses resource.getrusage(RUSAGE_SELF).ru_maxrss (which on
+        macOS reports BYTES, on Linux KB — both convert to MB).
+      - sustained_fps = measured_frames / wall_seconds_across_them.
+      - energy_joules optional, via `powermetrics --samplers cpu_power`.
+    """
+    FileHandle.standardError.write(Data((usage + "\n").utf8))
+}
+
+func fail(_ msg: String) -> Never {
+    FileHandle.standardError.write(Data("bench-essence: error: \(msg)\n".utf8))
+    exit(2)
+}
+
+// MARK: - WAV loader (16 kHz int16 mono, strict)
+
+enum WAVError: Error, CustomStringConvertible {
+    case readFailed(String)
+    case wrongSampleRate(Double)
+    case wrongChannelCount(UInt32)
+    case empty
+
+    var description: String {
+        switch self {
+        case .readFailed(let s): return "WAV read failed: \(s)"
+        case .wrongSampleRate(let r): return "WAV sample rate must be 16000, got \(Int(r))"
+        case .wrongChannelCount(let c): return "WAV must be mono (1 channel), got \(c)"
+        case .empty: return "WAV is empty"
+        }
+    }
+}
+
+func loadInt16Mono16k(_ url: URL) throws -> [Int16] {
+    let file: AVAudioFile
+    do {
+        file = try AVAudioFile(forReading: url)
+    } catch {
+        throw WAVError.readFailed("\(error)")
+    }
+    let nativeFmt = file.processingFormat
+    if nativeFmt.sampleRate != 16_000 {
+        throw WAVError.wrongSampleRate(nativeFmt.sampleRate)
+    }
+    if nativeFmt.channelCount != 1 {
+        throw WAVError.wrongChannelCount(nativeFmt.channelCount)
+    }
+
+    // Read into native (likely float32 mono) and convert to int16.
+    let frameCount = AVAudioFrameCount(file.length)
+    if frameCount == 0 { throw WAVError.empty }
+
+    guard let nativeBuf = AVAudioPCMBuffer(pcmFormat: nativeFmt, frameCapacity: frameCount) else {
+        throw WAVError.readFailed("alloc native buffer")
+    }
+    try file.read(into: nativeBuf)
+
+    let int16Fmt = AVAudioFormat(
+        commonFormat: .pcmFormatInt16,
+        sampleRate: 16_000,
+        channels: 1,
+        interleaved: true
+    )!
+    guard let i16Buf = AVAudioPCMBuffer(pcmFormat: int16Fmt, frameCapacity: frameCount) else {
+        throw WAVError.readFailed("alloc int16 buffer")
+    }
+    let conv = AVAudioConverter(from: nativeFmt, to: int16Fmt)!
+    var convErr: NSError?
+    _ = conv.convert(to: i16Buf, error: &convErr) { _, status in
+        status.pointee = .haveData
+        return nativeBuf
+    }
+    if let convErr { throw WAVError.readFailed("convert: \(convErr)") }
+
+    let n = Int(i16Buf.frameLength)
+    guard let chans = i16Buf.int16ChannelData else { throw WAVError.readFailed("no int16 channel data") }
+    return Array(UnsafeBufferPointer(start: chans[0], count: n))
+}
+
+// MARK: - sha256
+
+func sha256Hex(_ data: Data) -> String {
+    let digest = SHA256.hash(data: data)
+    return digest.map { String(format: "%02x", $0) }.joined()
+}
+
+func sha256OfFile(_ url: URL) throws -> String {
+    let data = try Data(contentsOf: url, options: .mappedIfSafe)
+    return sha256Hex(data)
+}
+
+/// Render `image` into a tightly-packed RGB byte buffer (R, G, B per
+/// pixel, row-major, no padding). Matches the Python sibling's
+/// `np.array(PIL.Image.open(...).convert("RGB"))` convention so SHA256
+/// + PSNR are computed on identical bytes.
+func cgImageRGBBytes(_ image: CGImage) -> Data {
+    let w = image.width
+    let h = image.height
+    // CG doesn't natively support 24-bit RGB contexts on Apple
+    // platforms; we render into 32-bit RGBA then strip the alpha.
+    let rgbaBytesPerRow = w * 4
+    var rgba = [UInt8](repeating: 0, count: rgbaBytesPerRow * h)
+    // Use explicit sRGB to match cv2 conventions; DeviceRGB picks up the
+    // display profile on Apple Silicon and color-matches sRGB sources.
+    let cs = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+    rgba.withUnsafeMutableBytes { ptr in
+        guard let base = ptr.baseAddress else { return }
+        let info = CGImageAlphaInfo.premultipliedLast.rawValue
+        if let ctx = CGContext(
+            data: base,
+            width: w, height: h,
+            bitsPerComponent: 8, bytesPerRow: rgbaBytesPerRow,
+            space: cs, bitmapInfo: info
+        ) {
+            ctx.draw(image, in: CGRect(x: 0, y: 0, width: w, height: h))
+        }
+    }
+    let bytesPerRow = w * 3
+    var rgb = [UInt8](repeating: 0, count: bytesPerRow * h)
+    for i in 0..<(w * h) {
+        rgb[i * 3 + 0] = rgba[i * 4 + 0]
+        rgb[i * 3 + 1] = rgba[i * 4 + 1]
+        rgb[i * 3 + 2] = rgba[i * 4 + 2]
+    }
+    return Data(rgb)
+}
+
+// MARK: - PSNR
+
+/// Peak-signal-to-noise ratio in dB between two equal-shape RGB byte
+/// buffers. Matches the Python sibling's formula exactly:
+/// `mse = mean((a - b)^2)`, `psnr = 10*log10(255^2 / mse)`. Returns
+/// `+inf` when `mse == 0` (byte-identical frames).
+func psnrRGB(_ a: Data, _ b: Data) -> Double {
+    precondition(a.count == b.count, "PSNR inputs must be the same size")
+    if a.count == 0 { return .infinity }
+    var sumSq: UInt64 = 0
+    a.withUnsafeBytes { ap in
+        b.withUnsafeBytes { bp in
+            let pa = ap.bindMemory(to: UInt8.self).baseAddress!
+            let pb = bp.bindMemory(to: UInt8.self).baseAddress!
+            for i in 0..<a.count {
+                let d = Int(pa[i]) - Int(pb[i])
+                sumSq &+= UInt64(d * d)
+            }
+        }
+    }
+    let mse = Double(sumSq) / Double(a.count)
+    if mse == 0 { return .infinity }
+    return 10.0 * log10(255.0 * 255.0 / mse)
+}
+
+// MARK: - Reference loader
+
+/// Loads `<dir>/<frameIdx-padded-5>.png` if present and returns its
+/// RGB bytes. Returns nil if the file doesn't exist.
+func loadReferenceRGB(_ dir: URL, frameIdx: Int) -> Data? {
+    let name = String(format: "%05d.png", frameIdx)
+    let url = dir.appendingPathComponent(name)
+    guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+    guard let src = CGImageSourceCreateWithURL(url as CFURL, nil),
+          let img = CGImageSourceCreateImageAtIndex(src, 0, nil) else {
+        return nil
+    }
+    return cgImageRGBBytes(img)
+}
+
+// MARK: - RSS sampler (Mac, mach_task_basic_info)
+
+/// Returns peak resident set size of THIS process in bytes, sampled
+/// from `mach_task_basic_info::resident_size_max`. Matches the Python
+/// sibling's `resource.getrusage(RUSAGE_SELF).ru_maxrss`; both report
+/// the high-water mark, both convert to MB on emit.
+func currentPeakRSSBytes() -> UInt64 {
+    var info = mach_task_basic_info()
+    var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info_data_t>.size / MemoryLayout<natural_t>.size)
+    let kr = withUnsafeMutablePointer(to: &info) { infoPtr -> kern_return_t in
+        infoPtr.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { reboundPtr in
+            task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), reboundPtr, &count)
+        }
+    }
+    guard kr == KERN_SUCCESS else { return 0 }
+    return UInt64(info.resident_size_max)
+}
+
+/// Background sampler that polls peak RSS at 100 Hz and reports the
+/// max it ever saw on `stop()`.
+final class RSSSampler: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "bench-essence.rss")
+    private var maxBytes: UInt64 = 0
+    private var stopped: Bool = false
+    private let lock = NSLock()
+    private let intervalNs: UInt64 = 10_000_000  // 10 ms = 100 Hz
+
+    func start() {
+        queue.async { [weak self] in
+            while let self {
+                self.lock.lock()
+                if self.stopped { self.lock.unlock(); return }
+                self.lock.unlock()
+                let cur = currentPeakRSSBytes()
+                self.lock.lock()
+                if cur > self.maxBytes { self.maxBytes = cur }
+                self.lock.unlock()
+                Thread.sleep(forTimeInterval: TimeInterval(self.intervalNs) / 1e9)
+            }
+        }
+    }
+
+    /// Stop and return peak RSS in megabytes (decimal MB, matching Python).
+    func stopAndReportMB() -> Double {
+        lock.lock()
+        stopped = true
+        // Take one last sample so an extremely short run still gets a value.
+        let last = currentPeakRSSBytes()
+        if last > maxBytes { maxBytes = last }
+        let bytes = maxBytes
+        lock.unlock()
+        return Double(bytes) / (1024.0 * 1024.0)
+    }
+}
+
+// MARK: - powermetrics
+
+/// Runs `powermetrics --samplers cpu_power -i 100 -n 50` synchronously,
+/// parses the average CPU Power lines, and converts to total joules
+/// over the sampling window. Returns nil if powermetrics isn't
+/// available, fails (it requires sudo on most setups), or the output
+/// can't be parsed.
+///
+/// Note on energy units: `powermetrics` reports power in mW (or W
+/// depending on macOS version). We sum power across the 50 100-ms
+/// samples = 5 s window: `J = sum(W_i * 0.1)`. Mac-only.
+func runPowermetrics(intervalMs: Int = 100, samples: Int = 50) -> Double? {
+    // Skipped on moraga capacity-test runs — powermetrics needs sudo, and we
+    // care about CPU/RAM/throughput, not joules.
+    return nil
+    let p = Process()
+    p.launchPath = "/usr/bin/sudo"
+    p.arguments = [
+        "-n",  // non-interactive; if no NOPASSWD this fails immediately
+        "powermetrics",
+        "--samplers", "cpu_power",
+        "-i", "\(intervalMs)",
+        "-n", "\(samples)",
+    ]
+    let pipe = Pipe()
+    p.standardOutput = pipe
+    p.standardError = Pipe()
+    do {
+        try p.run()
+    } catch {
+        return nil
+    }
+    p.waitUntilExit()
+    if p.terminationStatus != 0 { return nil }
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    guard let txt = String(data: data, encoding: .utf8) else { return nil }
+    return parsePowermetricsJoules(txt, intervalMs: intervalMs)
+}
+
+func parsePowermetricsJoules(_ output: String, intervalMs: Int) -> Double? {
+    // Look for lines like:
+    //   "CPU Power: 1234 mW"  or  "Combined Power (CPU + GPU + ANE): 1.5 W"
+    // Sum the numeric values, treating mW as mW, W as W.
+    var totalJ: Double = 0
+    var matched = 0
+    let intervalSec = Double(intervalMs) / 1000.0
+    for line in output.split(separator: "\n") {
+        let s = String(line)
+        guard s.lowercased().contains("cpu power:") else { continue }
+        // Tail after the colon.
+        guard let colon = s.firstIndex(of: ":") else { continue }
+        let tail = s[s.index(after: colon)...].trimmingCharacters(in: .whitespaces)
+        // Expect "<num> mW" or "<num> W".
+        let parts = tail.split(separator: " ", maxSplits: 1).map { String($0) }
+        guard parts.count == 2, let v = Double(parts[0]) else { continue }
+        let watts: Double
+        switch parts[1].lowercased() {
+        case "mw": watts = v / 1000.0
+        case "w":  watts = v
+        default:   continue
+        }
+        totalJ += watts * intervalSec
+        matched += 1
+    }
+    return matched > 0 ? totalJ : nil
+}
+
+// MARK: - CSV writer
+
+struct FrameRow {
+    let frameIdx: Int
+    let wallTimeMs: Double
+    let clusterIdx: Int
+    let frameSha256: String
+    /// `nil` when no reference dir was passed; `+inf` for byte-identical frames.
+    let psnrVsReference: Double?
+}
+
+struct CSVWriter {
+    let url: URL
+
+    func write(_ rows: [FrameRow]) throws {
+        var lines = ["frame_idx,wall_time_ms,cluster_idx,frame_sha256,psnr_vs_reference"]
+        for r in rows {
+            let psnrField: String
+            if let p = r.psnrVsReference {
+                if p.isInfinite {
+                    psnrField = "inf"
+                } else {
+                    psnrField = String(format: "%.6f", p)
+                }
+            } else {
+                psnrField = ""
+            }
+            // `%.6f` for ms is enough — 1 ns resolution.
+            lines.append(String(
+                format: "%d,%.6f,%d,%@,%@",
+                r.frameIdx, r.wallTimeMs, r.clusterIdx,
+                r.frameSha256 as NSString, psnrField as NSString
+            ))
+        }
+        let blob = lines.joined(separator: "\n") + "\n"
+        try blob.write(to: url, atomically: true, encoding: .utf8)
+    }
+}
+
+// MARK: - meta.json
+
+struct MetaHostInfo: Encodable {
+    let machine: String
+    let os: String
+    let mlx_version: String
+    let cpu_count: Int
+    let physical_memory_bytes: UInt64
+}
+
+struct MetaFixture: Encodable {
+    let imx_path: String
+    let imx_sha256: String
+    let audio_path: String
+    let audio_sha256: String
+    let frame_count_total: Int
+    let warmup_frames: Int
+    let measured_frames: Int
+}
+
+struct MetaMetrics: Encodable {
+    let cold_start_ms: Double
+    let per_frame_ms_mean: Double
+    let per_frame_ms_p99: Double
+    let peak_rss_mb: Double
+    let sustained_fps: Double
+    let energy_joules: Double?
+
+    // Swift's default Optional encoding omits the key when the value
+    // is nil, which would drift from the Python sibling's
+    // `json.dumps(asdict(...))` (which emits `"energy_joules": null`).
+    // Force-emit the key so both sides have an identical meta.json
+    // schema regardless of whether powermetrics ran.
+    enum CodingKeys: String, CodingKey {
+        case cold_start_ms, per_frame_ms_mean, per_frame_ms_p99
+        case peak_rss_mb, sustained_fps, energy_joules
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(cold_start_ms, forKey: .cold_start_ms)
+        try c.encode(per_frame_ms_mean, forKey: .per_frame_ms_mean)
+        try c.encode(per_frame_ms_p99, forKey: .per_frame_ms_p99)
+        try c.encode(peak_rss_mb, forKey: .peak_rss_mb)
+        try c.encode(sustained_fps, forKey: .sustained_fps)
+        if let e = energy_joules {
+            try c.encode(e, forKey: .energy_joules)
+        } else {
+            try c.encodeNil(forKey: .energy_joules)
+        }
+    }
+}
+
+struct MetaCorrectness: Encodable {
+    let reference_dir: String?
+    let psnr_mean: Double?
+    let psnr_min: Double?
+    let psnr_p1: Double?
+    let frames_with_reference: Int
+
+    // Force-emit nullable keys (see MetaMetrics for rationale).
+    enum CodingKeys: String, CodingKey {
+        case reference_dir, psnr_mean, psnr_min, psnr_p1, frames_with_reference
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        if let v = reference_dir { try c.encode(v, forKey: .reference_dir) }
+        else { try c.encodeNil(forKey: .reference_dir) }
+        if let v = psnr_mean { try c.encode(v, forKey: .psnr_mean) }
+        else { try c.encodeNil(forKey: .psnr_mean) }
+        if let v = psnr_min { try c.encode(v, forKey: .psnr_min) }
+        else { try c.encodeNil(forKey: .psnr_min) }
+        if let v = psnr_p1 { try c.encode(v, forKey: .psnr_p1) }
+        else { try c.encodeNil(forKey: .psnr_p1) }
+        try c.encode(frames_with_reference, forKey: .frames_with_reference)
+    }
+}
+
+struct Meta: Encodable {
+    let sdk: String
+    let sdk_version: String
+    let host: MetaHostInfo
+    let fixture: MetaFixture
+    let metrics: MetaMetrics
+    let correctness: MetaCorrectness
+}
+
+func hostMachineString() -> String {
+    // `uname.machine` is a fixed-size C char array; Swift imports it
+    // as a tuple. `sysctlbyname("hw.machine", ...)` is the cleaner
+    // path and gives the same answer (e.g. "arm64", "x86_64") plus
+    // `hw.model` for the human-readable model string.
+    var size: size_t = 0
+    sysctlbyname("hw.model", nil, &size, nil, 0)
+    if size > 0 {
+        var buf = [CChar](repeating: 0, count: size)
+        sysctlbyname("hw.model", &buf, &size, nil, 0)
+        return String(cString: buf)
+    }
+    return "unknown"
+}
+
+func hostInfo() -> MetaHostInfo {
+    let osVersion = ProcessInfo.processInfo.operatingSystemVersionString
+    let cpuCount = ProcessInfo.processInfo.processorCount
+    let physMem = ProcessInfo.processInfo.physicalMemory
+    // mlx_version: not trivially queryable from Swift at runtime.
+    // Leave as the build-pinned major; the Python side fills the
+    // resolved version. Both sides record the value they have.
+    let mlxVersion = "0.31.x (Package.swift pin)"
+    return MetaHostInfo(
+        machine: hostMachineString(),
+        os: osVersion,
+        mlx_version: mlxVersion,
+        cpu_count: cpuCount,
+        physical_memory_bytes: physMem
+    )
+}
+
+// MARK: - Stats helpers
+
+func percentile(_ values: [Double], _ p: Double) -> Double {
+    guard !values.isEmpty else { return .nan }
+    let sorted = values.sorted()
+    let pos = max(0.0, min(1.0, p)) * Double(sorted.count - 1)
+    let lo = Int(pos.rounded(.down))
+    let hi = min(lo + 1, sorted.count - 1)
+    let frac = pos - Double(lo)
+    return sorted[lo] * (1 - frac) + sorted[hi] * frac
+}
+
+func mean(_ values: [Double]) -> Double {
+    guard !values.isEmpty else { return .nan }
+    return values.reduce(0, +) / Double(values.count)
+}
+
+// MARK: - Dry-run mode (smoke test for CSV writer + RSS sampler)
+
+func runDryRun(output: URL) throws {
+    try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+    let sampler = RSSSampler()
+    sampler.start()
+    var rows: [FrameRow] = []
+    let measuredCount = 5
+    for i in 0..<measuredCount {
+        let t0 = DispatchTime.now().uptimeNanoseconds
+        // Pretend we did some work.
+        Thread.sleep(forTimeInterval: 0.005)
+        let t1 = DispatchTime.now().uptimeNanoseconds
+        rows.append(FrameRow(
+            frameIdx: i,
+            wallTimeMs: Double(t1 - t0) / 1_000_000.0,
+            clusterIdx: i % 7,
+            frameSha256: String(repeating: "0", count: 64),
+            psnrVsReference: nil
+        ))
+    }
+    let peakMB = sampler.stopAndReportMB()
+    let csvURL = output.appendingPathComponent("bench.csv")
+    try CSVWriter(url: csvURL).write(rows)
+
+    let times = rows.map { $0.wallTimeMs }
+    let metaURL = output.appendingPathComponent("meta.json")
+    let meta = Meta(
+        sdk: "swift",
+        sdk_version: "0.0.0-dryrun",
+        host: hostInfo(),
+        fixture: MetaFixture(
+            imx_path: "<dry-run>",
+            imx_sha256: String(repeating: "0", count: 64),
+            audio_path: "<dry-run>",
+            audio_sha256: String(repeating: "0", count: 64),
+            frame_count_total: measuredCount,
+            warmup_frames: 0,
+            measured_frames: measuredCount
+        ),
+        metrics: MetaMetrics(
+            cold_start_ms: 0,
+            per_frame_ms_mean: mean(times),
+            per_frame_ms_p99: percentile(times, 0.99),
+            peak_rss_mb: peakMB,
+            sustained_fps: 0,
+            energy_joules: nil
+        ),
+        correctness: MetaCorrectness(
+            reference_dir: nil,
+            psnr_mean: nil,
+            psnr_min: nil,
+            psnr_p1: nil,
+            frames_with_reference: 0
+        )
+    )
+    let enc = JSONEncoder()
+    enc.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try enc.encode(meta)
+    try data.write(to: metaURL)
+    print("dry-run wrote \(csvURL.path) and \(metaURL.path); peak_rss_mb=\(String(format: "%.2f", peakMB))")
+}
+
+// MARK: - Multi-instance memory check
+
+/// Validates the shared-fixture API: load one ``EssenceFixture``,
+/// build N runtimes off it, drive a few frames through each, sample
+/// peak RSS at each step. Reports the per-instance RSS delta — the
+/// metric that matters for "how many concurrent avatars fit on this
+/// machine."
+func runMultiInstanceCheck(args: CLIArgs) async throws {
+    guard let fixture = args.fixture else { fail("--fixture is required") }
+    guard let audio = args.audio else { fail("--audio is required") }
+    if !FileManager.default.fileExists(atPath: fixture.path) {
+        fail("fixture not found: \(fixture.path)")
+    }
+    if !FileManager.default.fileExists(atPath: audio.path) {
+        fail("audio not found: \(audio.path)")
+    }
+
+    let n = args.multiInstance
+    let perInstanceFrames = args.multiInstanceFrames
+    let samplesPerFrame = 640
+    let samples = try loadInt16Mono16k(audio)
+    if samples.count < perInstanceFrames * samplesPerFrame {
+        fail("audio has \(samples.count) samples; need \(perInstanceFrames * samplesPerFrame) for \(perInstanceFrames) frames")
+    }
+
+    func mb(_ bytes: UInt64) -> Double { Double(bytes) / (1024.0 * 1024.0) }
+    let baselineRSS = currentPeakRSSBytes()
+    print(String(format: "multi-instance check: N=%d, framesPerInstance=%d", n, perInstanceFrames))
+    print(String(format: "  baseline RSS                                    %8.2f MB", mb(baselineRSS)))
+
+    let fixtureLoadStart = DispatchTime.now().uptimeNanoseconds
+    let essenceFixture = try Bithuman.loadEssenceFixture(modelPath: fixture)
+    let fixtureLoadEnd = DispatchTime.now().uptimeNanoseconds
+    let fixtureLoadMs = Double(fixtureLoadEnd - fixtureLoadStart) / 1_000_000.0
+    let postFixtureRSS = currentPeakRSSBytes()
+    print(String(format: "  fixture loaded in %.1f ms; RSS                  %8.2f MB  (Δ %+8.2f)",
+                 fixtureLoadMs, mb(postFixtureRSS), mb(postFixtureRSS) - mb(baselineRSS)))
+
+    var runtimes: [EssenceRuntime] = []
+    runtimes.reserveCapacity(n)
+    var rssAfter: [UInt64] = []
+    rssAfter.reserveCapacity(n)
+    for k in 0..<n {
+        let createStart = DispatchTime.now().uptimeNanoseconds
+        let rt = try Bithuman.createRuntime(fixture: essenceFixture)
+        let createEnd = DispatchTime.now().uptimeNanoseconds
+        let createMs = Double(createEnd - createStart) / 1_000_000.0
+        // Drive a small audio batch to populate per-instance LRU + composedCache.
+        for idx in 0..<perInstanceFrames {
+            let off = idx * samplesPerFrame
+            let chunk = Array(samples[off..<(off + samplesPerFrame)])
+            _ = try await rt._generateFrameDetailedForBench(audioChunk: chunk)
+        }
+        runtimes.append(rt)
+        let rss = currentPeakRSSBytes()
+        rssAfter.append(rss)
+        let priorRSS = k == 0 ? postFixtureRSS : rssAfter[k - 1]
+        print(String(format: "  +runtime[%2d] built in %.1f ms + drove %d frames; RSS %8.2f MB  (Δ %+7.2f)",
+                     k, createMs, perInstanceFrames, mb(rss), mb(rss) - mb(priorRSS)))
+    }
+
+    let finalRSS = rssAfter.last ?? postFixtureRSS
+    let totalSharedDelta = mb(postFixtureRSS) - mb(baselineRSS)
+    let totalRuntimesDelta = mb(finalRSS) - mb(postFixtureRSS)
+    let perInstanceMean = n > 0 ? totalRuntimesDelta / Double(n) : 0
+    print("---")
+    print(String(format: "  fixture buffers (shared once)                  %8.2f MB", totalSharedDelta))
+    print(String(format: "  N=%d runtime instances delta                    %8.2f MB  (mean %.2f MB / runtime)",
+                 n, totalRuntimesDelta, perInstanceMean))
+    print(String(format: "  total RSS at end                               %8.2f MB", mb(finalRSS)))
+
+    // Verify all runtimes produced consistent idle frames (their
+    // pre-computed shared CGImage should be byte-identical).
+    let firstIdle = await runtimes[0].idleFrame
+    var allMatch = true
+    for k in 1..<runtimes.count {
+        let img = await runtimes[k].idleFrame
+        if img.width != firstIdle.width || img.height != firstIdle.height {
+            allMatch = false
+            print("  ⚠ runtime[\(k)].idleFrame dim mismatch: \(img.width)×\(img.height) vs \(firstIdle.width)×\(firstIdle.height)")
+        }
+    }
+    if allMatch {
+        print(String(format: "  ✓ all %d runtimes report identical idleFrame dims (%dx%d)",
+                     n, firstIdle.width, firstIdle.height))
+    }
+
+    // ── Concurrent real-time stress (moraga capacity test) ────────────
+    //
+    // The serial check above proves N runtimes FIT in memory. This phase
+    // proves they can be DRIVEN at 25 FPS concurrently. Spawn N async
+    // tasks; each pushes one 640-sample chunk per "tick" for `concurrentTicks`
+    // ticks; we measure aggregate p50/p99 frame time and whether any
+    // runtime fell behind real-time (> 40 ms / frame).
+    let concurrentTicks = ProcessInfo.processInfo.environment["BITHUMAN_CONC_TICKS"].flatMap { Int($0) } ?? 75
+    let h264Enabled = ProcessInfo.processInfo.environment["BITHUMAN_BENCH_H264"] == "1"
+    if concurrentTicks > 0, samples.count >= concurrentTicks * samplesPerFrame {
+        print("---")
+        let mode = h264Enabled ? "render + H.264 encode (VideoToolbox HW)" : "render only"
+        print(String(format: "  concurrent real-time drive: N=%d × %d ticks (%@) — target 40 ms/frame @ 25 FPS",
+                     n, concurrentTicks, mode))
+        // Pre-slice the audio chunks once so per-tick overhead is just the dispatch.
+        var chunks: [[Int16]] = []
+        chunks.reserveCapacity(concurrentTicks)
+        for t in 0..<concurrentTicks {
+            let off = t * samplesPerFrame
+            chunks.append(Array(samples[off..<(off + samplesPerFrame)]))
+        }
+        actor TimingCollector {
+            var samples: [Double] = []
+            func add(_ ms: Double) { samples.append(ms) }
+        }
+        let collector = TimingCollector()
+        // Resolution is fixed per fixture; query once for VTCompressionSession setup.
+        let firstRt = runtimes[0]
+        let resolution = await firstRt.resolution
+        let outW = Int32(resolution.width)
+        let outH = Int32(resolution.height)
+        let wallStart = DispatchTime.now().uptimeNanoseconds
+        await withTaskGroup(of: Void.self) { group in
+            for k in 0..<n {
+                let rt = runtimes[k]
+                let myChunks = chunks
+                group.addTask {
+                    // Each task owns its own H.264 encoder (production server
+                    // would have one per session for independent egress).
+                    var encSession: VTCompressionSession?
+                    if h264Enabled {
+                        let attrs: [String: Any] = [
+                            kVTCompressionPropertyKey_RealTime as String: true,
+                            kVTCompressionPropertyKey_AllowFrameReordering as String: false,
+                        ]
+                        VTCompressionSessionCreate(
+                            allocator: nil, width: outW, height: outH,
+                            codecType: kCMVideoCodecType_H264,
+                            encoderSpecification: nil,
+                            imageBufferAttributes: nil,
+                            compressedDataAllocator: nil,
+                            outputCallback: nil, refcon: nil,
+                            compressionSessionOut: &encSession)
+                        if let s = encSession {
+                            for (k, v) in attrs {
+                                VTSessionSetProperty(s, key: k as CFString, value: v as CFTypeRef)
+                            }
+                            VTSessionSetProperty(s, key: kVTCompressionPropertyKey_AverageBitRate, value: 2_000_000 as CFNumber)
+                            VTSessionSetProperty(s, key: kVTCompressionPropertyKey_ExpectedFrameRate, value: 25 as CFNumber)
+                            VTCompressionSessionPrepareToEncodeFrames(s)
+                        }
+                    }
+                    var pts = CMTime(value: 0, timescale: 25)
+                    for chunk in myChunks {
+                        let s = DispatchTime.now().uptimeNanoseconds
+                        let detail = try? await rt._generateFrameDetailedForBench(audioChunk: chunk)
+                        if h264Enabled, let img = detail?.image, let session = encSession {
+                            // CGImage → CVPixelBuffer (BGRA), then encode.
+                            var pb: CVPixelBuffer?
+                            let pbAttrs: [String: Any] = [
+                                kCVPixelBufferIOSurfacePropertiesKey as String: [:],
+                            ]
+                            CVPixelBufferCreate(nil, Int(outW), Int(outH),
+                                                kCVPixelFormatType_32BGRA,
+                                                pbAttrs as CFDictionary, &pb)
+                            if let pixelBuffer = pb {
+                                CVPixelBufferLockBaseAddress(pixelBuffer, [])
+                                let ctx = CGContext(
+                                    data: CVPixelBufferGetBaseAddress(pixelBuffer),
+                                    width: Int(outW), height: Int(outH),
+                                    bitsPerComponent: 8,
+                                    bytesPerRow: CVPixelBufferGetBytesPerRow(pixelBuffer),
+                                    space: CGColorSpaceCreateDeviceRGB(),
+                                    bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
+                                              | CGBitmapInfo.byteOrder32Little.rawValue
+                                )
+                                ctx?.draw(img, in: CGRect(x: 0, y: 0, width: Int(outW), height: Int(outH)))
+                                CVPixelBufferUnlockBaseAddress(pixelBuffer, [])
+                                VTCompressionSessionEncodeFrame(
+                                    session, imageBuffer: pixelBuffer,
+                                    presentationTimeStamp: pts,
+                                    duration: CMTime(value: 1, timescale: 25),
+                                    frameProperties: nil,
+                                    sourceFrameRefcon: nil,
+                                    infoFlagsOut: nil)
+                                VTCompressionSessionCompleteFrames(session,
+                                    untilPresentationTimeStamp: pts)
+                            }
+                            pts = CMTime(value: pts.value + 1, timescale: 25)
+                        }
+                        let e = DispatchTime.now().uptimeNanoseconds
+                        await collector.add(Double(e - s) / 1_000_000.0)
+                    }
+                    if let s = encSession { VTCompressionSessionInvalidate(s) }
+                }
+            }
+        }
+        let wallEnd = DispatchTime.now().uptimeNanoseconds
+        let wallSec = Double(wallEnd - wallStart) / 1e9
+        let timings = await collector.samples
+        let sorted = timings.sorted()
+        let p50 = sorted[sorted.count / 2]
+        let p99 = sorted[Int(Double(sorted.count) * 0.99)]
+        let mean = timings.reduce(0, +) / Double(timings.count)
+        let maxMs = sorted.last ?? 0
+        let overBudget = timings.filter { $0 > 40.0 }.count
+        let totalFrames = timings.count
+        let aggregateFps = Double(totalFrames) / wallSec
+        let perInstanceFps = aggregateFps / Double(n)
+        let realTimeRatio = perInstanceFps / 25.0
+        print(String(format: "  wall=%.2fs  total_frames=%d  aggregate_fps=%.1f  per_instance_fps=%.2f (real-time ratio %.2fx)",
+                     wallSec, totalFrames, aggregateFps, perInstanceFps, realTimeRatio))
+        print(String(format: "  per-frame ms — mean=%.2f  p50=%.2f  p99=%.2f  max=%.2f  over_40ms=%d (%.1f%%)",
+                     mean, p50, p99, maxMs, overBudget, 100.0 * Double(overBudget) / Double(totalFrames)))
+    }
+
+    _ = runtimes  // pin for measurement; release happens at scope exit
+}
+
+// MARK: - Main
+
+func runBench(args: CLIArgs) async throws {
+    guard let fixture = args.fixture else { fail("--fixture is required") }
+    guard let audio = args.audio else { fail("--audio is required") }
+    guard let output = args.output else { fail("--output is required") }
+    guard args.warmup < args.frames else {
+        fail("--warmup (\(args.warmup)) must be < --frames (\(args.frames))")
+    }
+    if !FileManager.default.fileExists(atPath: fixture.path) {
+        fail("fixture not found: \(fixture.path)")
+    }
+    if !FileManager.default.fileExists(atPath: audio.path) {
+        fail("audio not found: \(audio.path)")
+    }
+    try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+
+    // --- Hash inputs ---------------------------------------------------
+    let imxSha = try sha256OfFile(fixture)
+    let audioSha = try sha256OfFile(audio)
+
+    // --- Load WAV ------------------------------------------------------
+    let samples = try loadInt16Mono16k(audio)
+    let samplesPerFrame = 640  // 16 kHz / 25 fps
+    let needSamples = samplesPerFrame * args.frames
+    if samples.count < needSamples {
+        fail("audio has \(samples.count) samples; need at least \(needSamples) for \(args.frames) frames at 25 FPS / 16 kHz")
+    }
+
+    // --- Start RSS sampler --------------------------------------------
+    let rss = RSSSampler()
+    rss.start()
+
+    // --- Load runtime + cold-start timer ------------------------------
+    let createReturnedAt = DispatchTime.now().uptimeNanoseconds
+    let runtimeSum = try Bithuman.createRuntime(modelPath: fixture)
+    guard case .essence(let runtime) = runtimeSum else {
+        fail(".imx is not an Essence model (createRuntime returned \(runtimeSum))")
+    }
+
+    // --- Optional: dump audio encoder embedding for a fixed mel input
+    // Used to verify the Swift MLX encoder agrees with the ONNX
+    // reference. BITHUMAN_DUMP_EMB=<melPath>:<outPath> reads a raw
+    // float32 mel of shape (1, 1, 80, 16) and writes the (1, 512, 1, 1)
+    // embedding as flat row-major float32 to outPath. After the dump
+    // the bench exits cleanly so the comparator can run against it.
+    if let spec = ProcessInfo.processInfo.environment["BITHUMAN_DUMP_EMB"] {
+        let parts = spec.split(separator: ":", maxSplits: 1).map(String.init)
+        guard parts.count == 2 else { fail("BITHUMAN_DUMP_EMB must be melPath:outPath") }
+        let melData = try Data(contentsOf: URL(fileURLWithPath: parts[0]))
+        let melCount = 80 * 16
+        guard melData.count == melCount * MemoryLayout<Float>.size else {
+            fail("mel input must be \(melCount) float32 values; got \(melData.count) bytes")
+        }
+        var mel = [Float](repeating: 0, count: melCount)
+        _ = mel.withUnsafeMutableBytes { dst in
+            melData.copyBytes(to: dst, count: melData.count)
+        }
+        let emb = await runtime._encodeMelForBench(mel: mel)
+        let outURL = URL(fileURLWithPath: parts[1])
+        let outBytes = emb.withUnsafeBufferPointer { bp in
+            Data(bytes: bp.baseAddress!, count: bp.count * MemoryLayout<Float>.size)
+        }
+        try outBytes.write(to: outURL)
+        print("wrote \(emb.count) float32 embedding values to \(outURL.path)")
+        return
+    }
+
+    // --- Run frames ----------------------------------------------------
+    var firstFrameWallNs: UInt64 = 0
+    var rows: [FrameRow] = []
+    rows.reserveCapacity(args.frames - args.warmup)
+    var measuredStartNs: UInt64 = 0
+    var measuredEndNs: UInt64 = 0
+
+    let referenceDir = args.reference
+    if let r = referenceDir, !FileManager.default.fileExists(atPath: r.path) {
+        fail("reference dir does not exist: \(r.path)")
+    }
+
+    for idx in 0..<args.frames {
+        let off = idx * samplesPerFrame
+        let chunk = Array(samples[off..<(off + samplesPerFrame)])
+
+        let frameStart = DispatchTime.now().uptimeNanoseconds
+        let detail = try await runtime._generateFrameDetailedForBench(audioChunk: chunk)
+        let frameEnd = DispatchTime.now().uptimeNanoseconds
+
+        if firstFrameWallNs == 0 { firstFrameWallNs = frameEnd }
+
+        // BITHUMAN_DUMP_EMB_NORM=1 prints the encoder embedding L2
+        // norm per frame so the int8 vs fp32 divergence (the v0.18.4
+        // cluster-collapse bug) can be diagnosed without a full
+        // numpy round-trip. fp32 path embeddings on real audio sit
+        // around |emb| ≈ 5–8; int8 path tends to ≈ 1–2 when the
+        // collapse is firing.
+        if ProcessInfo.processInfo.environment["BITHUMAN_DUMP_EMB_NORM"] == "1" {
+            FileHandle.standardError.write(Data(
+                String(format: "frame=%4d cluster=%3d |emb|=%6.3f\n",
+                       idx, detail.clusterIdx, detail.embedNorm).utf8
+            ))
+        }
+
+        if idx >= args.warmup {
+            if measuredStartNs == 0 { measuredStartNs = frameStart }
+            measuredEndNs = frameEnd
+
+            let rgb = cgImageRGBBytes(detail.image)
+            let sha = sha256Hex(rgb)
+
+            // Dump first 5 measured frames to <output>/frames/NNNNN.png for
+            // visual debug. Always on for now — cheap, ~5 PNGs total.
+            if idx - args.warmup < 5 {
+                let framesDir = output.appendingPathComponent("frames")
+                try? FileManager.default.createDirectory(at: framesDir, withIntermediateDirectories: true)
+                let fname = String(format: "%05d.png", idx)
+                let pngURL = framesDir.appendingPathComponent(fname)
+                if let dest = CGImageDestinationCreateWithURL(pngURL as CFURL, "public.png" as CFString, 1, nil) {
+                    CGImageDestinationAddImage(dest, detail.image, nil)
+                    _ = CGImageDestinationFinalize(dest)
+                }
+            }
+
+            var psnr: Double? = nil
+            if let refDir = referenceDir,
+               let refRGB = loadReferenceRGB(refDir, frameIdx: idx),
+               refRGB.count == rgb.count {
+                psnr = psnrRGB(rgb, refRGB)
+            }
+
+            rows.append(FrameRow(
+                frameIdx: idx,
+                wallTimeMs: Double(frameEnd - frameStart) / 1_000_000.0,
+                clusterIdx: detail.clusterIdx,
+                frameSha256: sha,
+                psnrVsReference: psnr
+            ))
+        }
+    }
+
+    let coldStartMs = Double(firstFrameWallNs - createReturnedAt) / 1_000_000.0
+    let peakRSSMB = rss.stopAndReportMB()
+
+    // --- Optional energy measurement (mac only) -----------------------
+    // Per spec we run powermetrics OVER the measured window, but since
+    // it samples at 100 ms × 50 = 5 s, and our measured window may be
+    // shorter or longer, we run it after the fact on a quiescent run
+    // — same spec command as the Python side, same parsing.
+    let energy = runPowermetrics()
+
+    // --- Aggregate metrics --------------------------------------------
+    let times = rows.map { $0.wallTimeMs }
+    let measuredFrames = rows.count
+    let measuredWallSec = Double(measuredEndNs - measuredStartNs) / 1e9
+    let sustainedFps = measuredWallSec > 0 ? Double(measuredFrames) / measuredWallSec : 0
+
+    // Correctness aggregates.
+    let psnrValues: [Double] = rows.compactMap { row -> Double? in
+        guard let p = row.psnrVsReference else { return nil }
+        // Skip +inf for distribution stats (it'd skew p1/min).
+        return p.isInfinite ? nil : p
+    }
+    let psnrMean: Double? = psnrValues.isEmpty ? nil : mean(psnrValues)
+    let psnrMin: Double? = psnrValues.isEmpty ? nil : psnrValues.min()
+    let psnrP1: Double? = psnrValues.isEmpty ? nil : percentile(psnrValues, 0.01)
+    let framesWithRef = rows.filter { $0.psnrVsReference != nil }.count
+
+    // --- Write CSV + meta.json ----------------------------------------
+    let csvURL = output.appendingPathComponent("bench.csv")
+    try CSVWriter(url: csvURL).write(rows)
+
+    let meta = Meta(
+        sdk: "swift",
+        sdk_version: bitHumanKitVersion(),
+        host: hostInfo(),
+        fixture: MetaFixture(
+            imx_path: fixture.path,
+            imx_sha256: imxSha,
+            audio_path: audio.path,
+            audio_sha256: audioSha,
+            frame_count_total: args.frames,
+            warmup_frames: args.warmup,
+            measured_frames: measuredFrames
+        ),
+        metrics: MetaMetrics(
+            cold_start_ms: coldStartMs,
+            per_frame_ms_mean: mean(times),
+            per_frame_ms_p99: percentile(times, 0.99),
+            peak_rss_mb: peakRSSMB,
+            sustained_fps: sustainedFps,
+            energy_joules: energy
+        ),
+        correctness: MetaCorrectness(
+            reference_dir: referenceDir?.path,
+            psnr_mean: psnrMean,
+            psnr_min: psnrMin,
+            psnr_p1: psnrP1,
+            frames_with_reference: framesWithRef
+        )
+    )
+    let metaURL = output.appendingPathComponent("meta.json")
+    let enc = JSONEncoder()
+    enc.outputFormatting = [.prettyPrinted, .sortedKeys]
+    enc.nonConformingFloatEncodingStrategy = .convertToString(
+        positiveInfinity: "Infinity",
+        negativeInfinity: "-Infinity",
+        nan: "NaN"
+    )
+    let data = try enc.encode(meta)
+    try data.write(to: metaURL)
+
+    print("wrote \(csvURL.path) (\(rows.count) rows)")
+    print("wrote \(metaURL.path)")
+    print("cold_start_ms=\(String(format: "%.2f", coldStartMs)) per_frame_ms_mean=\(String(format: "%.3f", mean(times))) per_frame_ms_p99=\(String(format: "%.3f", percentile(times, 0.99))) peak_rss_mb=\(String(format: "%.2f", peakRSSMB)) sustained_fps=\(String(format: "%.2f", sustainedFps))")
+    if ProcessInfo.processInfo.environment["BITHUMAN_PROFILE"] == "1" {
+        await runtime._dumpProfileForBench()
+    }
+}
+
+/// SDK version string. There's no compile-time bake of the SemVer in
+/// `bitHumanKit`; Swift surfaces the resolved Package.resolved tag at
+/// build time only. The bench harness reports the value embedded in
+/// `Package.swift` minor pin notation, which is consistent across the
+/// matrix of binaries we ship from this repo.
+func bitHumanKitVersion() -> String {
+    // TODO when bitHumanKit exposes a static `version` constant, swap
+    // this. For now the value is hand-aligned to the latest tag.
+    "0.10.0"
+}
+
+// MARK: - Entry point
+
+// Touch the metallib bootstrap so it actually runs (top-level lets
+// in executable targets are otherwise lazy on first reference).
+_ = _ensureMetalLibraryAtStartup
+
+let args = CLIArgs.parse()
+
+if args.dryRun {
+    do {
+        guard let output = args.output else {
+            fail("--output is required for --dry-run")
+        }
+        try runDryRun(output: output)
+        exit(0)
+    } catch {
+        FileHandle.standardError.write(Data("dry-run failed: \(error)\n".utf8))
+        exit(1)
+    }
+}
+
+// Keep a Task reference alive across dispatchMain; the Task closure
+// itself terminates the process via `exit(...)`, so dispatchMain is
+// the right primary loop here.
+_ = Task {
+    do {
+        if args.multiInstance > 0 {
+            try await runMultiInstanceCheck(args: args)
+        } else {
+            try await runBench(args: args)
+        }
+        exit(0)
+    } catch {
+        FileHandle.standardError.write(Data("bench-essence failed: \(error)\n".utf8))
+        exit(1)
+    }
+}
+
+dispatchMain()

--- a/Examples/swift/compare-dit/Package.swift
+++ b/Examples/swift/compare-dit/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+// CompareDiT — render a WAV through the avatar engine to a lip-synced
+// MP4, to A/B fp16 vs int4 DiT quality. Targets the Layer-1 Expression
+// avatar engine directly (the `Expression` product), so it pulls in the
+// renderer without the STT/LLM/TTS umbrella. See README.md.
+let package = Package(
+    name: "CompareDiT",
+    platforms: [
+        .macOS("26.0")
+    ],
+    dependencies: [
+        .package(name: "bithuman",
+                 url: "https://github.com/bithuman-product/bithuman-sdk-public.git",
+                 from: "0.8.1")
+    ],
+    targets: [
+        .executableTarget(
+            name: "CompareDiT",
+            dependencies: [
+                .product(name: "Expression", package: "bithuman")
+            ],
+            path: "Sources/CompareDiT",
+            swiftSettings: [.swiftLanguageMode(.v5)]
+        )
+    ]
+)

--- a/Examples/swift/compare-dit/README.md
+++ b/Examples/swift/compare-dit/README.md
@@ -1,0 +1,33 @@
+# CompareDiT
+
+Render a WAV through the bitHuman avatar engine to a lip-synced MP4, to
+A/B fp16 vs int4 DiT quality side by side. Targets the Layer-1
+**Expression** avatar engine directly (the `Expression` product) — no
+STT/LLM/TTS umbrella.
+
+## Run
+
+```bash
+cd Examples/swift/compare-dit
+swift build -c release --product CompareDiT
+
+# fp16 (default)
+.build/release/CompareDiT --model expression.imx --audio ref.wav --output fp16.mp4
+
+# int4 (quantized DiT)
+FH_QUANTIZE_DIT=int4 .build/release/CompareDiT \
+  --model expression.imx --audio ref.wav --output int4.mp4
+
+# stack them
+ffmpeg -i fp16.mp4 -i int4.mp4 \
+  -filter_complex "[0:v][1:v]hstack" -map 0:a side-by-side.mp4
+```
+
+Flags: `--model/-m`, `--audio/-a`, `--output/-o`, `--identity/-i`,
+`--driver/-d`, `--quality/-q {medium|high}`, `--putback`.
+
+## Requires
+
+- macOS 26+ (Tahoe), Apple Silicon M3+ (Expression is unsupported on
+  M1/M2 — raises `ExpressionModelNotSupported`)
+- An `.imx` Expression model and a reference WAV

--- a/Examples/swift/compare-dit/Sources/CompareDiT/CompareDiT.swift
+++ b/Examples/swift/compare-dit/Sources/CompareDiT/CompareDiT.swift
@@ -1,0 +1,720 @@
+// CompareDiT — render a WAV through the avatar engine to a lip-synced MP4.
+//
+// Used to A/B fp16 vs int4 DiT quality:
+//
+//   swift build -c release --product compare-dit
+//   compare-dit --model expression.imx --audio ref.wav --output fp16.mp4
+//   FH_QUANTIZE_DIT=int4 compare-dit --model expression.imx --audio ref.wav --output int4.mp4
+//   ffmpeg -i fp16.mp4 -i int4.mp4 -filter_complex "[0:v][1:v]hstack" \
+//     -map 0:a side-by-side.mp4
+//
+// Adapted from bithuman-expression-swift/Examples/HelloWorld; uses
+// bitHumanKit's public unmetered factory. SDK-internal constants
+// (FRAME_NUM=33, SAMPLE_RATE=16000, TGT_FPS=25) inlined here because
+// they're not part of the public API.
+
+import AVFoundation
+// Targets the Layer-1 Expression avatar engine directly (engine/expression
+// → the `Expression` product). Home of the `Bithuman` actor,
+// `Bithuman.Identity`, and `Bithuman.Quality` used below.
+import Expression
+import CoreGraphics
+import CoreMedia
+import CoreVideo
+import Foundation
+
+private let SDK_FRAME_NUM = 33
+private let SDK_SAMPLE_RATE = 16_000
+private let SDK_TGT_FPS = 25
+
+// MARK: - CLI
+
+struct CLIArgs {
+    var model: URL
+    var audio: URL
+    var output: URL
+    var identity: URL?
+    var driver: URL?
+    var quality: Bithuman.Quality = .medium
+    var putback: Bool = false
+
+    static func parse() throws -> CLIArgs {
+        let raw = Array(CommandLine.arguments.dropFirst())
+        var model: URL?, audio: URL?, output: URL?, identity: URL?, driver: URL?
+        var quality: Bithuman.Quality = .medium
+        var putback = false
+        var i = 0
+        while i < raw.count {
+            let arg = raw[i]
+            let val: () throws -> String = {
+                guard i + 1 < raw.count else { throw CLIError.missingValue(arg) }
+                i += 1
+                return raw[i]
+            }
+            switch arg {
+            case "--model", "-m":    model = URL(fileURLWithPath: try val())
+            case "--audio", "-a":    audio = URL(fileURLWithPath: try val())
+            case "--output", "-o":   output = URL(fileURLWithPath: try val())
+            case "--identity", "-i": identity = URL(fileURLWithPath: try val())
+            case "--driver", "-d":   driver = URL(fileURLWithPath: try val())
+            case "--quality", "-q":
+                let v = try val()
+                guard let q = Bithuman.Quality(rawValue: v) else {
+                    throw CLIError.unknownArg("--quality \(v) (expected: medium|high)")
+                }
+                quality = q
+            case "--putback":        putback = true
+            case "-h", "--help":     printUsage(); exit(0)
+            default:                 throw CLIError.unknownArg(arg)
+            }
+            i += 1
+        }
+        guard let model, let audio else {
+            printUsage()
+            throw CLIError.missingRequired
+        }
+        return CLIArgs(
+            model: model, audio: audio,
+            output: output ?? URL(fileURLWithPath: "demo.mp4"),
+            identity: identity,
+            driver: driver,
+            quality: quality,
+            putback: putback
+        )
+    }
+
+    static func printUsage() {
+        print("""
+        compare-dit — render a WAV through the avatar engine to MP4
+
+        Usage:
+          compare-dit --model PATH --audio PATH [--output PATH] \\
+                      [--identity PATH | --driver PATH] \\
+                      [--quality medium|high] [--putback]
+
+        Quality:
+          medium    2-step DiT (default, realtime-safe)
+          high      4-step DiT (offline video) — note: visibly halos
+                    the face on the current .bhx; prefer medium
+
+        --putback   Composite the animated head crop back onto the
+                    full-resolution --identity portrait. Output mp4 is
+                    at source-portrait dimensions.
+
+        --driver    Drive putback with a video instead of a static
+                    portrait. First frame becomes engine identity;
+                    every video frame becomes the per-tick canvas;
+                    Vision face detection runs per-frame and is
+                    temporally Gaussian-smoothed (σ=2) to track
+                    gentle head motion without jitter. Implicitly
+                    enables --putback. Output mp4 is at driver-video
+                    dimensions.
+
+        Env:
+          FH_QUANTIZE_DIT=int4 (or int8)  Quantize DiT before inference.
+        """)
+    }
+}
+
+enum CLIError: Error, CustomStringConvertible {
+    case missingValue(String), unknownArg(String), missingRequired
+    var description: String {
+        switch self {
+        case .missingValue(let a): return "missing value for \(a)"
+        case .unknownArg(let a):   return "unknown argument: \(a)"
+        case .missingRequired:     return "both --model and --audio are required"
+        }
+    }
+}
+
+enum CompareError: Error, CustomStringConvertible {
+    case audio(String), video(String), cli(String)
+    var description: String {
+        switch self {
+        case .audio(let m): return "audio: \(m)"
+        case .video(let m): return "video: \(m)"
+        case .cli(let m):   return m
+        }
+    }
+}
+
+// MARK: - WAV loader
+
+func loadWAV(_ url: URL) throws -> (samples: [Float], sampleRate: Int) {
+    let audioFile = try AVAudioFile(forReading: url)
+    let fmt = AVAudioFormat(
+        commonFormat: .pcmFormatFloat32,
+        sampleRate: audioFile.processingFormat.sampleRate,
+        channels: 1, interleaved: false
+    )!
+    let frameCount = AVAudioFrameCount(audioFile.length)
+    guard let buffer = AVAudioPCMBuffer(pcmFormat: fmt, frameCapacity: frameCount) else {
+        throw CompareError.audio("could not allocate PCM buffer")
+    }
+    guard let native = AVAudioPCMBuffer(
+        pcmFormat: audioFile.processingFormat,
+        frameCapacity: frameCount
+    ) else {
+        throw CompareError.audio("could not allocate native-format buffer")
+    }
+    try audioFile.read(into: native)
+
+    let converter = AVAudioConverter(from: audioFile.processingFormat, to: fmt)!
+    var error: NSError?
+    _ = converter.convert(to: buffer, error: &error, withInputFrom: { _, outStatus in
+        outStatus.pointee = .haveData
+        return native
+    })
+    if let error { throw CompareError.audio("convert failed: \(error)") }
+
+    let n = Int(buffer.frameLength)
+    guard let ptr = buffer.floatChannelData?[0] else {
+        throw CompareError.audio("no float channel data")
+    }
+    return (Array(UnsafeBufferPointer(start: ptr, count: n)), Int(fmt.sampleRate))
+}
+
+func resample(_ samples: [Float], from src: Int, to dst: Int) -> [Float] {
+    if src == dst { return samples }
+    let ratio = Double(dst) / Double(src)
+    let n = Int((Double(samples.count) * ratio).rounded())
+    var out = [Float](repeating: 0, count: n)
+    for i in 0..<n {
+        let pos = Double(i) / ratio
+        let lo = Int(pos.rounded(.down))
+        let hi = min(lo + 1, samples.count - 1)
+        let frac = Float(pos - Double(lo))
+        out[i] = samples[lo] * (1 - frac) + samples[hi] * frac
+    }
+    return out
+}
+
+// MARK: - MP4 writer
+
+final class MP4Writer: @unchecked Sendable {
+    private let writer: AVAssetWriter
+    private let videoInput: AVAssetWriterInput
+    private let audioInput: AVAssetWriterInput
+    private let pixelAdaptor: AVAssetWriterInputPixelBufferAdaptor
+    private let videoFPS: Int32 = 25
+    private let audioSR: Int32 = 24_000
+    private let width: Int
+    private let height: Int
+
+    private let videoQueue = DispatchQueue(label: "compare-dit.mp4.video")
+    private let audioQueue = DispatchQueue(label: "compare-dit.mp4.audio")
+
+    private let lock = NSLock()
+    private var pendingFrames: [(CGImage, CMTime)] = []
+    private var pendingAudio:  [CMSampleBuffer]     = []
+    private var videoEOS = false
+    private var audioEOS = false
+    private var videoMarkedFinished = false
+    private var audioMarkedFinished = false
+    private var finishStarted = false
+    private var nextFrameIndex: Int = 0
+    private var audioSamplesWritten: Int64 = 0
+
+    private let maxPendingFrames = 50
+    private let maxPendingAudio  = 10
+
+    init(url: URL, width: Int, height: Int) throws {
+        try? FileManager.default.removeItem(at: url)
+        self.writer = try AVAssetWriter(outputURL: url, fileType: .mp4)
+        self.width  = width
+        self.height = height
+
+        let videoSettings: [String: Any] = [
+            AVVideoCodecKey:  AVVideoCodecType.h264,
+            AVVideoWidthKey:  width,
+            AVVideoHeightKey: height,
+        ]
+        self.videoInput = AVAssetWriterInput(mediaType: .video, outputSettings: videoSettings)
+        self.videoInput.expectsMediaDataInRealTime = false
+
+        let audioSettings: [String: Any] = [
+            AVFormatIDKey:         kAudioFormatMPEG4AAC,
+            AVSampleRateKey:       audioSR,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderBitRateKey:   64_000,
+        ]
+        self.audioInput = AVAssetWriterInput(mediaType: .audio, outputSettings: audioSettings)
+        self.audioInput.expectsMediaDataInRealTime = false
+
+        self.pixelAdaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: videoInput,
+            sourcePixelBufferAttributes: [
+                kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+                kCVPixelBufferWidthKey as String:           width,
+                kCVPixelBufferHeightKey as String:          height,
+            ]
+        )
+
+        writer.add(videoInput)
+        writer.add(audioInput)
+        writer.startWriting()
+        writer.startSession(atSourceTime: .zero)
+
+        videoInput.requestMediaDataWhenReady(on: videoQueue) { [weak self] in
+            self?.drainVideo()
+        }
+        audioInput.requestMediaDataWhenReady(on: audioQueue) { [weak self] in
+            self?.drainAudio()
+        }
+    }
+
+    func append(frame: CGImage) async throws {
+        try checkWriterStatus()
+        try lock.withLock {
+            if finishStarted { throw CompareError.video("append(frame:) after finish()") }
+            let pts = CMTime(value: CMTimeValue(nextFrameIndex), timescale: videoFPS)
+            nextFrameIndex += 1
+            pendingFrames.append((frame, pts))
+        }
+        try await applyBackpressure(kind: .video)
+    }
+
+    func append(audio samples: [Float]) async throws {
+        guard !samples.isEmpty else { return }
+        try checkWriterStatus()
+        let pts: CMTime = try lock.withLock {
+            if finishStarted { throw CompareError.audio("append(audio:) after finish()") }
+            let pts = CMTime(value: audioSamplesWritten, timescale: audioSR)
+            audioSamplesWritten &+= Int64(samples.count)
+            return pts
+        }
+        guard let sbuf = Self.makeAudioSampleBuffer(samples: samples, pts: pts, sampleRate: audioSR) else {
+            throw CompareError.audio("could not build CMSampleBuffer for \(samples.count) samples")
+        }
+        lock.withLock { pendingAudio.append(sbuf) }
+        try await applyBackpressure(kind: .audio)
+    }
+
+    private enum BackpressureKind { case video, audio }
+
+    private func applyBackpressure(kind: BackpressureKind) async throws {
+        while true {
+            try checkWriterStatus()
+            let tooFull: Bool = lock.withLock {
+                switch kind {
+                case .video: return pendingFrames.count > maxPendingFrames
+                case .audio: return pendingAudio.count  > maxPendingAudio
+                }
+            }
+            if !tooFull { return }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+    }
+
+    private func drainVideo() {
+        while videoInput.isReadyForMoreMediaData {
+            let item: (CGImage, CMTime)?
+            let shouldFinish: Bool
+            (item, shouldFinish) = lock.withLock {
+                if pendingFrames.isEmpty {
+                    return (nil, videoEOS && !videoMarkedFinished)
+                }
+                return (pendingFrames.removeFirst(), false)
+            }
+            if let (cg, pts) = item {
+                appendPixelBuffer(for: cg, pts: pts)
+                continue
+            }
+            if shouldFinish {
+                videoInput.markAsFinished()
+                lock.withLock { videoMarkedFinished = true }
+            }
+            return
+        }
+    }
+
+    private func drainAudio() {
+        while audioInput.isReadyForMoreMediaData {
+            let sbuf: CMSampleBuffer?
+            let shouldFinish: Bool
+            (sbuf, shouldFinish) = lock.withLock {
+                if pendingAudio.isEmpty {
+                    return (nil, audioEOS && !audioMarkedFinished)
+                }
+                return (pendingAudio.removeFirst(), false)
+            }
+            if let sbuf {
+                audioInput.append(sbuf)
+                continue
+            }
+            if shouldFinish {
+                audioInput.markAsFinished()
+                lock.withLock { audioMarkedFinished = true }
+            }
+            return
+        }
+    }
+
+    private func appendPixelBuffer(for frame: CGImage, pts: CMTime) {
+        guard let pool = pixelAdaptor.pixelBufferPool else { return }
+        var buf: CVPixelBuffer?
+        CVPixelBufferPoolCreatePixelBuffer(nil, pool, &buf)
+        guard let pb = buf else { return }
+
+        CVPixelBufferLockBaseAddress(pb, [])
+        let ctx = CGContext(
+            data: CVPixelBufferGetBaseAddress(pb),
+            width: width, height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: CVPixelBufferGetBytesPerRow(pb),
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.noneSkipFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
+        )
+        ctx?.draw(frame, in: CGRect(x: 0, y: 0, width: width, height: height))
+        CVPixelBufferUnlockBaseAddress(pb, [])
+
+        pixelAdaptor.append(pb, withPresentationTime: pts)
+    }
+
+    private static func makeAudioSampleBuffer(
+        samples: [Float], pts: CMTime, sampleRate: Int32
+    ) -> CMSampleBuffer? {
+        var asbd = AudioStreamBasicDescription(
+            mSampleRate: Float64(sampleRate),
+            mFormatID: kAudioFormatLinearPCM,
+            mFormatFlags: kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked,
+            mBytesPerPacket: 4, mFramesPerPacket: 1,
+            mBytesPerFrame: 4, mChannelsPerFrame: 1,
+            mBitsPerChannel: 32, mReserved: 0
+        )
+        var formatDesc: CMFormatDescription?
+        CMAudioFormatDescriptionCreate(
+            allocator: kCFAllocatorDefault, asbd: &asbd,
+            layoutSize: 0, layout: nil,
+            magicCookieSize: 0, magicCookie: nil,
+            extensions: nil, formatDescriptionOut: &formatDesc
+        )
+        guard let formatDesc else { return nil }
+
+        var block: CMBlockBuffer?
+        let bytes = samples.count * MemoryLayout<Float>.size
+        CMBlockBufferCreateWithMemoryBlock(
+            allocator: kCFAllocatorDefault, memoryBlock: nil,
+            blockLength: bytes, blockAllocator: nil, customBlockSource: nil,
+            offsetToData: 0, dataLength: bytes, flags: 0, blockBufferOut: &block
+        )
+        guard let block else { return nil }
+        _ = samples.withUnsafeBufferPointer { ptr -> OSStatus in
+            CMBlockBufferReplaceDataBytes(
+                with: ptr.baseAddress!, blockBuffer: block,
+                offsetIntoDestination: 0, dataLength: bytes
+            )
+        }
+
+        var timing = CMSampleTimingInfo(
+            duration: CMTime(value: CMTimeValue(samples.count), timescale: sampleRate),
+            presentationTimeStamp: pts,
+            decodeTimeStamp: .invalid
+        )
+        var sampleSize = MemoryLayout<Float>.size
+        var sbuf: CMSampleBuffer?
+        CMSampleBufferCreate(
+            allocator: kCFAllocatorDefault, dataBuffer: block, dataReady: true,
+            makeDataReadyCallback: nil, refcon: nil, formatDescription: formatDesc,
+            sampleCount: CMItemCount(samples.count),
+            sampleTimingEntryCount: 1, sampleTimingArray: &timing,
+            sampleSizeEntryCount: 1, sampleSizeArray: &sampleSize,
+            sampleBufferOut: &sbuf
+        )
+        return sbuf
+    }
+
+    private func checkWriterStatus() throws {
+        if writer.status == .failed {
+            throw CompareError.video("AVAssetWriter failed: \(writer.error?.localizedDescription ?? "unknown")")
+        }
+        if writer.status == .cancelled {
+            throw CompareError.video("AVAssetWriter cancelled")
+        }
+    }
+
+    func finish() async throws {
+        let alreadyStarted: Bool = lock.withLock {
+            if finishStarted { return true }
+            finishStarted = true
+            videoEOS = true
+            audioEOS = true
+            return false
+        }
+        if alreadyStarted { return }
+
+        videoQueue.async { [weak self] in self?.drainVideo() }
+        audioQueue.async { [weak self] in self?.drainAudio() }
+
+        let deadline = CFAbsoluteTimeGetCurrent() + 120.0
+        while true {
+            try checkWriterStatus()
+            let done: Bool = lock.withLock {
+                videoMarkedFinished && audioMarkedFinished
+                    && pendingFrames.isEmpty && pendingAudio.isEmpty
+            }
+            if done { break }
+            if CFAbsoluteTimeGetCurrent() > deadline {
+                throw CompareError.video("finish() timed out (status=\(writer.status.rawValue))")
+            }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+
+        await writer.finishWriting()
+    }
+}
+
+private extension NSLock {
+    @inline(__always)
+    func withLock<T>(_ body: () -> T) -> T {
+        lock(); defer { unlock() }
+        return body()
+    }
+    @inline(__always)
+    func withLock<T>(_ body: () throws -> T) throws -> T {
+        lock(); defer { unlock() }
+        return try body()
+    }
+}
+
+// MARK: - main
+
+@main
+struct CompareDiT {
+    static func main() async {
+        do {
+            try await run()
+        } catch {
+            FileHandle.standardError.write(Data("error: \(error)\n".utf8))
+            exit(1)
+        }
+    }
+
+    static func run() async throws {
+        let args = try CLIArgs.parse()
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: args.model.path) else {
+            throw CompareError.cli("model file not found: \(args.model.path)")
+        }
+        guard fm.fileExists(atPath: args.audio.path) else {
+            throw CompareError.cli("audio file not found: \(args.audio.path)")
+        }
+        if let ident = args.identity, !fm.fileExists(atPath: ident.path) {
+            throw CompareError.cli("identity file not found: \(ident.path)")
+        }
+        if let drv = args.driver, !fm.fileExists(atPath: drv.path) {
+            throw CompareError.cli("driver video not found: \(drv.path)")
+        }
+        if args.identity != nil && args.driver != nil {
+            throw CompareError.cli("--identity and --driver are mutually exclusive")
+        }
+        if args.putback && args.driver == nil {
+            guard let ident = args.identity else {
+                throw CompareError.cli("--putback requires --identity PATH or --driver PATH")
+            }
+            let ext = ident.pathExtension.lowercased()
+            guard ext != "npy" else {
+                throw CompareError.cli("--putback needs an image portrait, not a pre-encoded latent")
+            }
+        }
+        do { _ = try AVAudioFile(forReading: args.audio) } catch {
+            throw CompareError.audio("could not read \(args.audio.lastPathComponent) — \(error.localizedDescription)")
+        }
+
+        let dtypeLabel = ProcessInfo.processInfo.environment["FH_QUANTIZE_DIT"] ?? "fp16"
+        print("→ DiT mode: \(dtypeLabel)")
+        print("→ Quality: \(args.quality.rawValue) (\(args.quality.nSteps)-step)")
+        print("→ Loading model: \(args.model.lastPathComponent)")
+
+        // --driver: extract the driver's first frame, write it out as a
+        // JPEG to /tmp, and use that as the engine identity so the
+        // animated face matches the person in the video.
+        var derivedIdentityURL: URL?
+        if let drv = args.driver {
+            print("→ Driver video: \(drv.lastPathComponent) — extracting first frame")
+            let firstCG = try Putback.firstFrame(of: drv)
+            let outURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("compare-dit-driver-id-\(ProcessInfo.processInfo.processIdentifier).jpg")
+            guard let dest = CGImageDestinationCreateWithURL(
+                outURL as CFURL, "public.jpeg" as CFString, 1, nil
+            ) else { throw CompareError.cli("could not write driver identity jpg") }
+            CGImageDestinationAddImage(dest, firstCG, [
+                kCGImageDestinationLossyCompressionQuality as String: 0.95
+            ] as CFDictionary)
+            guard CGImageDestinationFinalize(dest) else {
+                throw CompareError.cli("could not finalize driver identity jpg")
+            }
+            derivedIdentityURL = outURL
+        }
+
+        let identity: Bithuman.Identity = {
+            if let url = derivedIdentityURL { return .image(url) }
+            guard let ident = args.identity else { return .default }
+            let ext = ident.pathExtension.lowercased()
+            return (ext == "npy") ? .preEncoded(ident) : .image(ident)
+        }()
+
+        let result = try Bithuman.create(
+            modelPath: args.model, identity: identity, quality: args.quality
+        )
+        let bithuman = result.bithuman
+        let size = bithuman.frameSize
+        print("→ Ready: \(Int(size.width))×\(Int(size.height))")
+
+        let samples: [Float]
+        let sr: Int
+        do {
+            (samples, sr) = try loadWAV(args.audio)
+        } catch {
+            throw CompareError.audio("could not read \(args.audio.lastPathComponent) — \(error.localizedDescription)")
+        }
+        let samples16 = resample(samples, from: sr, to: 16_000)
+        let samples24 = resample(samples, from: sr, to: 24_000)
+        print(String(format: "→ Pushed %.2fs of audio @ %d Hz", Double(samples.count) / Double(sr), sr))
+
+        try await bithuman.pushAudio(audio24k: samples24, audio16k: samples16)
+
+        let dispatchSamples16 = SDK_FRAME_NUM * SDK_SAMPLE_RATE / SDK_TGT_FPS
+        if samples16.count < dispatchSamples16 {
+            await bithuman.flushTailIfNeeded()
+        }
+
+        // Decide canvas mode:
+        //   driver        → per-frame video canvas, per-frame smoothed crop
+        //   putback+ident → static portrait canvas, single crop
+        //   else          → head-only (engine crop, no putback)
+        let putbackPlan: PutbackPlan?
+        let outW: Int
+        let outH: Int
+        if let drv = args.driver {
+            let plan = try Putback.makeDriverPlan(driverURL: drv)
+            let p0 = plan.paramsPerFrame.first
+            print(String(format: "→ Driver-putback: canvas %d×%d @ %.1f fps, %d frames, crop_size[0]=%.0fpx angle[0]=%.1f°",
+                          plan.outWidth, plan.outHeight, plan.canvasFPS,
+                          plan.canvasFrames.count,
+                          p0?.size ?? 0,
+                          (p0?.angle ?? 0) * 180 / .pi))
+            putbackPlan = plan
+            outW = plan.outWidth
+            outH = plan.outHeight
+        } else if args.putback, let portraitURL = args.identity {
+            let plan = try Putback.makePlan(portraitURL: portraitURL)
+            let p0 = plan.paramsPerFrame[0]
+            print(String(format: "→ Putback: source %d×%d, crop_size=%.0fpx angle=%.1f°",
+                          plan.outWidth, plan.outHeight, p0.size,
+                          p0.angle * 180 / .pi))
+            putbackPlan = plan
+            outW = plan.outWidth
+            outH = plan.outHeight
+        } else {
+            putbackPlan = nil
+            outW = Int(size.width)
+            outH = Int(size.height)
+        }
+
+        let writer = try MP4Writer(
+            url: args.output,
+            width: outW,
+            height: outH
+        )
+
+        // === Two-phase render for putback ===
+        //
+        // Ditto-style putback needs the engine output's *smoothed* anchor
+        // trajectory to compute clean per-frame affines, which means we
+        // have to know all engine frames before we can composite. So:
+        //
+        //   Phase A: drain all engine chunks → cache frames + per-frame
+        //            engine anchors. Audio gets written to mp4 streaming
+        //            (it doesn't depend on the smoothed anchors).
+        //   Phase B: temporally Gaussian-smooth the engine anchors, then
+        //            composite each frame onto its matching driver frame
+        //            and append to the writer.
+        //
+        // For head-only mode (no putbackPlan), phase A degenerates to
+        // direct frame writing — no buffering, no phase B.
+
+        var frameCount = 0
+        var tailPadded = false
+        let startupTimeout: TimeInterval = 60.0
+        let startTime = CFAbsoluteTimeGetCurrent()
+
+        var bufferedFrames: [CGImage] = []
+        var bufferedEnginePoses: [Putback.FacePose?] = []
+
+        func consumeChunk(_ chunk: TimedChunk) async throws {
+            if let audio = chunk.audio24k {
+                try await writer.append(audio: audio)
+            }
+            for frame in chunk.frames {
+                if putbackPlan != nil {
+                    // Phase A: buffer + detect full face pose (center +
+                    // angle) on each engine output for per-frame alignment.
+                    bufferedFrames.append(frame)
+                    bufferedEnginePoses.append(Putback.detectFacePose(cg: frame))
+                    frameCount += 1
+                } else {
+                    try await writer.append(frame: frame)
+                    frameCount += 1
+                }
+            }
+        }
+
+        while true {
+            if let chunk = bithuman.tryDequeueChunk() {
+                try await consumeChunk(chunk)
+                continue
+            }
+            try await Task.sleep(nanoseconds: 20_000_000)
+            if frameCount == 0 {
+                if CFAbsoluteTimeGetCurrent() - startTime > startupTimeout {
+                    throw CompareError.video("timed out waiting for first frame")
+                }
+                continue
+            }
+            let snap = bithuman.snapshot
+            if !snap.inFlight && (snap.pendingAudio16Count == 0 || snap.tailFlushedThisResponse) {
+                while let chunk = bithuman.tryDequeueChunk() {
+                    try await consumeChunk(chunk)
+                }
+                break
+            }
+            if !tailPadded && !snap.inFlight && snap.pendingAudio16Count > 0 {
+                await bithuman.flushTailIfNeeded()
+                tailPadded = true
+            }
+        }
+
+        // Phase B: putback composite. Smooth the per-frame engine FacePose
+        // (center + angle, detected during phase A) with light σ so the
+        // per-frame target tracks actual animation-induced shifts while
+        // suppressing Vision detection noise. Both engine and driver are
+        // detected per frame; M_o2c is built with the actual position
+        // and orientation each frame.
+        if let plan = putbackPlan {
+            let detectedEng = bufferedEnginePoses.compactMap { $0 }.count
+            FileHandle.standardError.write(Data(
+                "[Putback] engine: \(bufferedFrames.count) frames, \(detectedEng) FacePose detections\n".utf8
+            ))
+            let smoothedEnginePoses = Putback.smoothPoses(bufferedEnginePoses, sigma: 3.0)
+            for (i, engineFrame) in bufferedFrames.enumerated() {
+                let pose = smoothedEnginePoses[i]
+                guard let comp = Putback.compositeFrame(
+                    plan: plan,
+                    animatedFace: engineFrame,
+                    frameIndex: i,
+                    engineAnchorOverride: pose.center,
+                    engineAngleOverride: pose.angle
+                ) else {
+                    throw CompareError.video("putback composite returned nil at frame \(i)")
+                }
+                try await writer.append(frame: comp)
+            }
+        }
+
+        await bithuman.shutdown()
+        try await writer.finish()
+
+        print("→ ✓ Wrote \(args.output.lastPathComponent) — \(frameCount) frames @ 25 FPS (\(String(format: "%.1f", Double(frameCount)/25.0))s)")
+    }
+}

--- a/Examples/swift/compare-dit/Sources/CompareDiT/Putback.swift
+++ b/Examples/swift/compare-dit/Sources/CompareDiT/Putback.swift
@@ -1,0 +1,1231 @@
+// Putback — Ditto-style composite of the Expression engine's animated
+// face crop back onto a driver canvas. Mirrors the algorithm in
+// github.com/antgroup/ditto-talkinghead (`core/atomic_components/putback.py`
+// + `core/utils/crop.py`):
+//
+//   1. Compute per-frame M_o2c (original→crop) similarity transform from
+//      face landmarks. Anchor for angle = (eye_mid → mouth_mid); bbox =
+//      tight rect around all landmarks rotated into face-axis coords;
+//      scale = 1.5 with vy_ratio = -0.1 to include forehead. M_c2o is
+//      the inverse (crop→original).
+//   2. Use a STATIC soft-rectangle mask in CROP space (e.g. 384×384,
+//      inner 90% solid, 10% linear feather around the border).
+//   3. Warp BOTH the engine render AND the mask by the same M_c2o
+//      using vImage Lanczos-style high-quality resampling. The mask
+//      naturally follows the render because they share the warp.
+//   4. Blend per pixel:
+//          result = mask_warped * render_warped + (1 - mask_warped) * driver
+//
+// Smoothing for driver-video continuity: per-frame raw M_o2c parameters
+// (center.x, center.y, size, angle) get 1-D Gaussian smoothing across
+// the whole clip (σ=5 default) so Vision landmark noise doesn't cause
+// per-frame affine wobble.
+
+import Accelerate
+import AVFoundation
+import CoreGraphics
+import CoreVideo
+import Foundation
+import ImageIO
+import Vision
+
+// MARK: - Affine
+
+/// 2D affine x' = a·x + b·y + tx, y' = c·x + d·y + ty.
+struct Affine2D {
+    var a: Double, b: Double, c: Double, d: Double, tx: Double, ty: Double
+    static let identity = Affine2D(a: 1, b: 0, c: 0, d: 1, tx: 0, ty: 0)
+
+    func apply(_ p: CGPoint) -> CGPoint {
+        CGPoint(x: a * Double(p.x) + b * Double(p.y) + tx,
+                y: c * Double(p.x) + d * Double(p.y) + ty)
+    }
+
+    func inverse() -> Affine2D {
+        let det = a * d - b * c
+        let invDet = 1.0 / det
+        let ia =  d * invDet
+        let ib = -b * invDet
+        let ic = -c * invDet
+        let id =  a * invDet
+        return Affine2D(
+            a: ia, b: ib, c: ic, d: id,
+            tx: -(ia * tx + ib * ty),
+            ty: -(ic * tx + id * ty)
+        )
+    }
+}
+
+// MARK: - Face params (Ditto-style)
+
+/// Output of `parseRectFromLandmarks`. Determines the crop frame —
+/// center+size positions+sizes the face square in the source image,
+/// angle aligns it with the face's vertical axis.
+struct FaceCropParams {
+    var centerX: Double
+    var centerY: Double
+    var size: Double    // square side = 1.8 * max(faceW, faceH)
+    var angle: Double   // radians; rotation of face vertical axis from screen vertical
+    var faceW: Double   // Vision face rect width (unsmoothed source)
+    var faceH: Double   // Vision face rect height — needed for the engine's
+                        // yNudge=-0.20·faceH (NOT max(W,H)) to compute the
+                        // exact face anchor position in the engine 384 crop.
+}
+
+enum Putback {
+    // MARK: - Vision dense landmarks → flat point array
+
+    /// Extract all useful 2D landmark points (eye contours, brows, nose,
+    /// lips, face contour, pupils) in TOP-LEFT pixel coords. The bbox +
+    /// angle derivation in `parseRectFromLandmarks` uses all of them
+    /// for stable centroid + extent estimation.
+    static func detectLandmarkPoints(cg: CGImage) -> [CGPoint]? {
+        let req = VNDetectFaceLandmarksRequest()
+        let handler = VNImageRequestHandler(cgImage: cg, options: [:])
+        do { try handler.perform([req]) } catch { return nil }
+        return pointsFromObservation(
+            req.results, imgSize: CGSize(width: cg.width, height: cg.height)
+        )
+    }
+
+    static func detectLandmarkPoints(pixelBuffer: CVPixelBuffer) -> [CGPoint]? {
+        let req = VNDetectFaceLandmarksRequest()
+        let handler = VNImageRequestHandler(cvPixelBuffer: pixelBuffer, options: [:])
+        do { try handler.perform([req]) } catch { return nil }
+        return pointsFromObservation(
+            req.results,
+            imgSize: CGSize(width: CVPixelBufferGetWidth(pixelBuffer),
+                            height: CVPixelBufferGetHeight(pixelBuffer))
+        )
+    }
+
+    private static func pointsFromObservation(
+        _ results: [VNFaceObservation]?, imgSize: CGSize
+    ) -> [CGPoint]? {
+        guard let faces = results, !faces.isEmpty else { return nil }
+        let face = faces.max {
+            $0.boundingBox.width * $0.boundingBox.height
+                < $1.boundingBox.width * $1.boundingBox.height
+        }!
+        guard let lm = face.landmarks else { return nil }
+        let H = imgSize.height
+        func ptsTL(_ r: VNFaceLandmarkRegion2D?) -> [CGPoint] {
+            guard let r = r else { return [] }
+            return r.pointsInImage(imageSize: imgSize).map { CGPoint(x: $0.x, y: H - $0.y) }
+        }
+        var pts: [CGPoint] = []
+        pts.append(contentsOf: ptsTL(lm.faceContour))
+        pts.append(contentsOf: ptsTL(lm.leftEye))
+        pts.append(contentsOf: ptsTL(lm.rightEye))
+        pts.append(contentsOf: ptsTL(lm.leftEyebrow))
+        pts.append(contentsOf: ptsTL(lm.rightEyebrow))
+        pts.append(contentsOf: ptsTL(lm.nose))
+        pts.append(contentsOf: ptsTL(lm.noseCrest))
+        pts.append(contentsOf: ptsTL(lm.outerLips))
+        return pts.isEmpty ? nil : pts
+    }
+
+    // MARK: - Vision bbox + axis anchors
+
+    /// Convert a Vision normalized bbox (bottom-left origin, [0,1])
+    /// to a pixel-coord CGRect (top-left origin).
+    static func visionBBoxToPixelRect(_ bb: CGRect, imgSize: CGSize) -> CGRect {
+        let x = bb.origin.x * imgSize.width
+        let y = (1.0 - bb.origin.y - bb.height) * imgSize.height
+        let w = bb.width * imgSize.width
+        let h = bb.height * imgSize.height
+        return CGRect(x: x, y: y, width: w, height: h)
+    }
+
+    /// Extract eye_mid and mouth_mid centroids from VNFaceLandmarks2D
+    /// in top-left pixel coords. Returns (nil, nil) if not detectable.
+    static func extractAxisAnchors(
+        landmarks lm: VNFaceLandmarks2D?, imgSize: CGSize
+    ) -> (CGPoint?, CGPoint?) {
+        guard let lm = lm else { return (nil, nil) }
+        let H = imgSize.height
+        func centroid(_ r: VNFaceLandmarkRegion2D?) -> CGPoint? {
+            guard let r = r else { return nil }
+            let pts = r.pointsInImage(imageSize: imgSize).map { CGPoint(x: $0.x, y: H - $0.y) }
+            guard !pts.isEmpty else { return nil }
+            let sx = pts.reduce(0) { $0 + $1.x } / CGFloat(pts.count)
+            let sy = pts.reduce(0) { $0 + $1.y } / CGFloat(pts.count)
+            return CGPoint(x: sx, y: sy)
+        }
+        let lEye = centroid(lm.leftEye) ?? centroid(lm.leftPupil)
+        let rEye = centroid(lm.rightEye) ?? centroid(lm.rightPupil)
+        let lips = centroid(lm.outerLips) ?? centroid(lm.innerLips)
+        let eyeMid: CGPoint? = {
+            if let l = lEye, let r = rEye {
+                return CGPoint(x: (l.x + r.x) / 2, y: (l.y + r.y) / 2)
+            }
+            return lEye ?? rEye
+        }()
+        return (eyeMid, lips)
+    }
+
+    // MARK: - Face transform (Ditto's parse_rect_from_landmark)
+
+    /// Eye centroid + mouth centroid → 2-point face axis (uy = eye→mouth).
+    /// Falls back gracefully if mouth is missing.
+    private static func axisAnchors(cg: CGImage, imgSize: CGSize) -> (CGPoint, CGPoint)? {
+        // Re-run a focused request just to grab eye + lip centroids;
+        // callers that already have landmarks could re-use them, but
+        // the API stays simple this way.
+        let req = VNDetectFaceLandmarksRequest()
+        try? VNImageRequestHandler(cgImage: cg, options: [:]).perform([req])
+        guard let face = req.results?.max(by: {
+            $0.boundingBox.width * $0.boundingBox.height
+                < $1.boundingBox.width * $1.boundingBox.height
+        }), let lm = face.landmarks else { return nil }
+        let H = imgSize.height
+        func centroid(_ r: VNFaceLandmarkRegion2D?) -> CGPoint? {
+            guard let r = r else { return nil }
+            let pts = r.pointsInImage(imageSize: imgSize).map { CGPoint(x: $0.x, y: H - $0.y) }
+            guard !pts.isEmpty else { return nil }
+            let sx = pts.reduce(0) { $0 + $1.x } / CGFloat(pts.count)
+            let sy = pts.reduce(0) { $0 + $1.y } / CGFloat(pts.count)
+            return CGPoint(x: sx, y: sy)
+        }
+        let lEye = centroid(lm.leftEye) ?? centroid(lm.leftPupil)
+        let rEye = centroid(lm.rightEye) ?? centroid(lm.rightPupil)
+        let lips = centroid(lm.outerLips) ?? centroid(lm.innerLips)
+        guard let lEye, let rEye, let lips else { return nil }
+        let eyeMid = CGPoint(x: (lEye.x + rEye.x) / 2, y: (lEye.y + rEye.y) / 2)
+        return (eyeMid, lips)
+    }
+
+    /// Build FaceCropParams matching the Bithuman Expression engine's
+    /// internal crop EXACTLY (ImagePreprocess.faceAwareCropRect):
+    ///
+    ///   contextSide = max(faceW, faceH) * 1.8
+    ///   yNudge      = -0.20 * faceH                      (shifts up)
+    ///   center      = (faceCenter.x, faceCenter.y + yNudge)   (image-Y)
+    ///
+    /// The engine does an AXIS-ALIGNED crop (no rotation). The angle
+    /// recorded here is the face's tilt in canvas coords — used by
+    /// compositeFrame to compute the RELATIVE rotation between the
+    /// current frame and the first frame (the engine output's face
+    /// orientation matches whatever the first frame had).
+    static func paramsFromFaceRect(
+        faceRect: CGRect, eyeMid: CGPoint?, mouthMid: CGPoint?,
+        contextScale: Double = 1.8
+    ) -> FaceCropParams {
+        let faceW = Double(faceRect.width)
+        let faceH = Double(faceRect.height)
+        let faceCenterX = Double(faceRect.origin.x) + faceW / 2
+        let faceCenterY = Double(faceRect.origin.y) + faceH / 2
+        let size = max(faceW, faceH) * contextScale
+        var angle = 0.0
+        if let e = eyeMid, let m = mouthMid {
+            let dx = Double(m.x - e.x)
+            let dy = Double(m.y - e.y)
+            let l = (dx * dx + dy * dy).squareRoot()
+            if l > 1e-3 {
+                let uyx = dx / l, uyy = dy / l
+                let uxx = uyy
+                let uxy = -uyx
+                var a = acos(max(-1.0, min(1.0, uxx)))
+                if uxy < 0 { a = -a }
+                angle = a
+            }
+        }
+        // params.center stays at the ACTUAL face center (no yNudge baked
+        // into the params). The yNudge is already baked into the engine's
+        // 384 output (face is at (192, 234.67) inside, not (192, 192))
+        // because the engine's faceAwareCropRect applies yNudge to the
+        // crop region. We account for that in buildM_o2c by mapping the
+        // face center to the engine's face anchor, not the crop center.
+        return FaceCropParams(centerX: faceCenterX, centerY: faceCenterY,
+                              size: size, angle: angle,
+                              faceW: faceW, faceH: faceH)
+    }
+
+    /// Build M_o2c (original→crop). `targetCenter` is the crop pixel
+    /// where the canvas face center should land. For our setup that's
+    /// the engine's face anchor inside the 384 output, NOT the geometric
+    /// crop center — because the engine's faceAwareCropRect bakes the
+    /// yNudge into the crop, placing the face at (192, 234.67) when
+    /// the engine uses 1.8 context scale and -0.20 yNudge ratio.
+    ///
+    /// Rotation pivots around params.center (the face center on canvas)
+    /// so a tilted face maps to (targetCenter.x, targetCenter.y) for all θ.
+    static func buildM_o2c(params: FaceCropParams, dsize: Double,
+                            targetCenter: CGPoint) -> Affine2D {
+        let s = dsize / params.size
+        let cosA = cos(params.angle), sinA = sin(params.angle)
+        let cx = params.centerX, cy = params.centerY
+        let tcx = Double(targetCenter.x), tcy = Double(targetCenter.y)
+        return Affine2D(
+            a:  s * cosA,
+            b:  s * sinA,
+            c: -s * sinA,
+            d:  s * cosA,
+            tx: tcx - s * ( cosA * cx + sinA * cy),
+            ty: tcy - s * (-sinA * cx + cosA * cy)
+        )
+    }
+
+    // MARK: - Smoothing FaceCropParams across frames
+
+    private static func interpolateParams(_ xs: [FaceCropParams?]) -> [FaceCropParams?] {
+        let n = xs.count
+        guard n > 0 else { return xs }
+        let valid = (0..<n).filter { xs[$0] != nil }
+        guard !valid.isEmpty else { return xs }
+        var out = xs
+        let first = valid.first!, last = valid.last!
+        for i in 0..<first { out[i] = xs[first] }
+        for i in (last + 1)..<n { out[i] = xs[last] }
+        for k in 0..<(valid.count - 1) {
+            let lo = valid[k], hi = valid[k + 1]
+            if hi - lo <= 1 { continue }
+            let a = xs[lo]!, b = xs[hi]!
+            let span = Double(hi - lo)
+            for j in (lo + 1)..<hi {
+                let t = Double(j - lo) / span
+                out[j] = FaceCropParams(
+                    centerX: a.centerX + (b.centerX - a.centerX) * t,
+                    centerY: a.centerY + (b.centerY - a.centerY) * t,
+                    size:    a.size    + (b.size    - a.size)    * t,
+                    angle:   a.angle   + (b.angle   - a.angle)   * t,
+                    faceW:   a.faceW   + (b.faceW   - a.faceW)   * t,
+                    faceH:   a.faceH   + (b.faceH   - a.faceH)   * t
+                )
+            }
+        }
+        return out
+    }
+
+    private static func gaussianSmooth(_ xs: [Double], sigma: Double) -> [Double] {
+        let n = xs.count
+        guard n > 1, sigma > 0 else { return xs }
+        let radius = max(1, Int((3.0 * sigma).rounded()))
+        var kernel = [Double](repeating: 0, count: 2 * radius + 1)
+        var ksum = 0.0
+        for i in -radius...radius {
+            let w = exp(-Double(i * i) / (2 * sigma * sigma))
+            kernel[i + radius] = w
+            ksum += w
+        }
+        for k in 0..<kernel.count { kernel[k] /= ksum }
+        var out = [Double](repeating: 0, count: n)
+        for i in 0..<n {
+            var s = 0.0
+            for k in -radius...radius {
+                let idx = min(max(i + k, 0), n - 1)
+                s += xs[idx] * kernel[k + radius]
+            }
+            out[i] = s
+        }
+        return out
+    }
+
+    /// Smooth per-frame face crop params with a 1-D temporal Gaussian.
+    /// σ=5 by default; size + angle could conceivably use a larger σ
+    /// since they should be near-constant for a talking head, but σ=5
+    /// is already heavy enough.
+    /// Smooth per-frame face crop params with a 1-D temporal Gaussian.
+    /// Asymmetric σ: position (center) gets σ_pos = 5 to track gentle head
+    /// translation; size + angle + faceW/H get σ_size = 20 because a still
+    /// talking head shouldn't change size/orientation meaningfully — heavier
+    /// smoothing kills Vision noise that would otherwise show as breathing/
+    /// jitter in the warp.
+    static func smoothParams(_ raw: [FaceCropParams?],
+                              sigmaPos: Double = 2.0,
+                              sigmaSize: Double = 10.0) -> [FaceCropParams] {
+        let filled = interpolateParams(raw)
+        if filled.allSatisfy({ $0 == nil }) {
+            return Array(repeating: FaceCropParams(centerX: 0, centerY: 0, size: 1,
+                                                    angle: 0, faceW: 1, faceH: 1),
+                         count: raw.count)
+        }
+        let cxs = filled.map { $0?.centerX ?? 0 }
+        let cys = filled.map { $0?.centerY ?? 0 }
+        let szs = filled.map { $0?.size ?? 1 }
+        let ans = filled.map { $0?.angle ?? 0 }
+        let fws = filled.map { $0?.faceW ?? 1 }
+        let fhs = filled.map { $0?.faceH ?? 1 }
+        let sCx = gaussianSmooth(cxs, sigma: sigmaPos)
+        let sCy = gaussianSmooth(cys, sigma: sigmaPos)
+        let sSz = gaussianSmooth(szs, sigma: sigmaSize)
+        let sAn = gaussianSmooth(ans, sigma: sigmaSize)
+        let sFw = gaussianSmooth(fws, sigma: sigmaSize)
+        let sFh = gaussianSmooth(fhs, sigma: sigmaSize)
+        var out = [FaceCropParams]()
+        out.reserveCapacity(raw.count)
+        for i in 0..<raw.count {
+            out.append(FaceCropParams(centerX: sCx[i], centerY: sCy[i],
+                                       size: sSz[i], angle: sAn[i],
+                                       faceW: sFw[i], faceH: sFh[i]))
+        }
+        return out
+    }
+
+    // MARK: - Face polygon (face-shape mask in canvas coords)
+
+    /// Build an ordered ring of face-boundary points for a single image.
+    /// Returns polygon vertices in canvas pixel coords (top-left origin):
+    ///   jawline left → chin → jawline right → forehead arc (estimated
+    ///   by extending the eyebrow midline upward by ~0.55·eye_distance) →
+    ///   back to jawline left.
+    ///
+    /// Returns nil if landmark detection fails.
+    static func extractFacePolygon(cg: CGImage) -> [CGPoint]? {
+        let req = VNDetectFaceLandmarksRequest()
+        do { try VNImageRequestHandler(cgImage: cg, options: [:]).perform([req]) }
+        catch { return nil }
+        guard let face = req.results?.max(by: {
+            $0.boundingBox.width * $0.boundingBox.height
+                < $1.boundingBox.width * $1.boundingBox.height
+        }), let lm = face.landmarks else { return nil }
+        let imgSize = CGSize(width: cg.width, height: cg.height)
+        let H = imgSize.height
+        func ptsTL(_ r: VNFaceLandmarkRegion2D?) -> [CGPoint] {
+            guard let r = r else { return [] }
+            return r.pointsInImage(imageSize: imgSize).map { CGPoint(x: $0.x, y: H - $0.y) }
+        }
+        return facePolygonFromRegions(
+            faceContour: ptsTL(lm.faceContour),
+            leftEyebrow: ptsTL(lm.leftEyebrow),
+            rightEyebrow: ptsTL(lm.rightEyebrow),
+            leftEye: ptsTL(lm.leftEye),
+            rightEye: ptsTL(lm.rightEye)
+        )
+    }
+
+    /// CVPixelBuffer variant (used in driver streaming path).
+    static func extractFacePolygon(pixelBuffer: CVPixelBuffer) -> [CGPoint]? {
+        let req = VNDetectFaceLandmarksRequest()
+        do { try VNImageRequestHandler(cvPixelBuffer: pixelBuffer, options: [:]).perform([req]) }
+        catch { return nil }
+        guard let face = req.results?.max(by: {
+            $0.boundingBox.width * $0.boundingBox.height
+                < $1.boundingBox.width * $1.boundingBox.height
+        }), let lm = face.landmarks else { return nil }
+        let imgSize = CGSize(width: CVPixelBufferGetWidth(pixelBuffer),
+                              height: CVPixelBufferGetHeight(pixelBuffer))
+        let H = imgSize.height
+        func ptsTL(_ r: VNFaceLandmarkRegion2D?) -> [CGPoint] {
+            guard let r = r else { return [] }
+            return r.pointsInImage(imageSize: imgSize).map { CGPoint(x: $0.x, y: H - $0.y) }
+        }
+        return facePolygonFromRegions(
+            faceContour: ptsTL(lm.faceContour),
+            leftEyebrow: ptsTL(lm.leftEyebrow),
+            rightEyebrow: ptsTL(lm.rightEyebrow),
+            leftEye: ptsTL(lm.leftEye),
+            rightEye: ptsTL(lm.rightEye)
+        )
+    }
+
+    private static func facePolygonFromRegions(
+        faceContour: [CGPoint],
+        leftEyebrow: [CGPoint], rightEyebrow: [CGPoint],
+        leftEye: [CGPoint], rightEye: [CGPoint]
+    ) -> [CGPoint]? {
+        guard !faceContour.isEmpty else { return nil }
+        // Vision faceContour: ~17 points from one temple along the jawline
+        // to the other temple (no forehead). We add an estimated forehead
+        // arc above the eyebrows so the polygon encloses the whole face.
+
+        // Eye-line distance for forehead-height estimate.
+        let leftEyeC = centroid(leftEye)
+        let rightEyeC = centroid(rightEye)
+        let eyeDist: CGFloat
+        if let l = leftEyeC, let r = rightEyeC {
+            eyeDist = hypot(l.x - r.x, l.y - r.y)
+        } else {
+            // Fallback: face contour width
+            let xs = faceContour.map { $0.x }
+            eyeDist = (xs.max()! - xs.min()!) * 0.5
+        }
+        // Forehead arc: extend eyebrows upward in the local "face up"
+        // direction. For a near-upright face the up direction is image-Y
+        // negative. Use eye centroid → eyebrow centroid direction
+        // as the "face up" axis so we handle tilted heads correctly.
+        let foreheadHeight: CGFloat = eyeDist * 0.55
+        let leftBrowC = centroid(leftEyebrow) ?? leftEyeC
+        let rightBrowC = centroid(rightEyebrow) ?? rightEyeC
+        var foreheadArc: [CGPoint] = []
+        if let l = leftBrowC, let r = rightBrowC, let le = leftEyeC, let re = rightEyeC {
+            // Per-eyebrow "up" vector: from eye centroid to eyebrow centroid,
+            // normalized then scaled to foreheadHeight.
+            func extendUp(eyebrow: CGPoint, eye: CGPoint) -> CGPoint {
+                var dx = eyebrow.x - eye.x
+                var dy = eyebrow.y - eye.y
+                let len = hypot(dx, dy)
+                if len < 1 { dx = 0; dy = -1 } else { dx /= len; dy /= len }
+                return CGPoint(x: eyebrow.x + dx * foreheadHeight,
+                               y: eyebrow.y + dy * foreheadHeight)
+            }
+            let lFar = extendUp(eyebrow: l, eye: le)
+            let rFar = extendUp(eyebrow: r, eye: re)
+            // Build arc with one extra interpolated point at the top of
+            // the forehead so the polygon traces a curve, not a triangle.
+            let topMid = CGPoint(x: (lFar.x + rFar.x) / 2,
+                                 y: (lFar.y + rFar.y) / 2)
+            foreheadArc = [lFar, topMid, rFar]
+        }
+
+        // Assemble polygon: face contour (assumed temple→chin→temple) +
+        // forehead arc (right→left). Direction order matters for the
+        // winding-rule fill, but CG handles both — choose consistent.
+        // Vision's faceContour appears to go in a single direction along
+        // the jawline; we follow it then append forehead arc reversed
+        // so the polygon closes naturally.
+        var polygon = faceContour
+        polygon.append(contentsOf: foreheadArc)   // last → reversed in close
+        // If contour ends near the LEFT side and forehead arc starts on
+        // the LEFT, we'd double-back. Sort the polygon by angle around
+        // its centroid to get a clean ring — robust against Vision's
+        // contour ordering quirks.
+        return sortRing(polygon)
+    }
+
+    private static func centroid(_ pts: [CGPoint]) -> CGPoint? {
+        guard !pts.isEmpty else { return nil }
+        let sx = pts.reduce(0) { $0 + $1.x } / CGFloat(pts.count)
+        let sy = pts.reduce(0) { $0 + $1.y } / CGFloat(pts.count)
+        return CGPoint(x: sx, y: sy)
+    }
+
+    /// Sort polygon vertices by angle around their centroid so they form
+    /// a clean ring (no self-intersections).
+    private static func sortRing(_ pts: [CGPoint]) -> [CGPoint] {
+        guard pts.count >= 3 else { return pts }
+        let c = centroid(pts)!
+        return pts.sorted { a, b in
+            atan2(a.y - c.y, a.x - c.x) < atan2(b.y - c.y, b.x - c.x)
+        }
+    }
+
+    /// Rasterize a face polygon to a single-channel float32 mask in canvas
+    /// coords (top-left origin), with a Gaussian-feathered edge. Inside
+    /// the polygon = 1.0; outside = 0.0; edge transitions smoothly.
+    static func rasterizeFacePolygonMask(
+        polygon: [CGPoint], W: Int, H: Int, featherSigma: Double = 12.0
+    ) -> [Float] {
+        guard polygon.count >= 3 else {
+            return [Float](repeating: 0, count: W * H)
+        }
+        // 1. Draw filled polygon to an 8-bit grayscale buffer.
+        var bytes = [UInt8](repeating: 0, count: W * H)
+        bytes.withUnsafeMutableBytes { buf in
+            guard let ctx = CGContext(
+                data: buf.baseAddress, width: W, height: H,
+                bitsPerComponent: 8, bytesPerRow: W,
+                space: CGColorSpaceCreateDeviceGray(),
+                bitmapInfo: CGImageAlphaInfo.none.rawValue
+            ) else { return }
+            // CG bitmap contexts use bottom-left origin by default; flip
+            // Y so our top-left coords map directly.
+            ctx.translateBy(x: 0, y: CGFloat(H))
+            ctx.scaleBy(x: 1, y: -1)
+            ctx.setFillColor(gray: 1.0, alpha: 1.0)
+            ctx.beginPath()
+            ctx.move(to: polygon[0])
+            for p in polygon.dropFirst() { ctx.addLine(to: p) }
+            ctx.closePath()
+            ctx.fillPath()
+        }
+        // 2. Convert to float, apply Gaussian blur for feathered edge.
+        var floatMask = [Float](repeating: 0, count: W * H)
+        for i in 0..<bytes.count { floatMask[i] = Float(bytes[i]) / 255.0 }
+        if featherSigma > 0 {
+            floatMask = gaussianBlur2D(floatMask, W: W, H: H, sigma: featherSigma)
+        }
+        return floatMask
+    }
+
+    /// Simple separable Gaussian blur on a 1-channel float buffer.
+    private static func gaussianBlur2D(_ src: [Float], W: Int, H: Int, sigma: Double) -> [Float] {
+        let radius = max(1, Int((3.0 * sigma).rounded()))
+        var kernel = [Float](repeating: 0, count: 2 * radius + 1)
+        var ksum: Float = 0
+        for i in -radius...radius {
+            let w = Float(exp(-Double(i * i) / (2 * sigma * sigma)))
+            kernel[i + radius] = w
+            ksum += w
+        }
+        for k in 0..<kernel.count { kernel[k] /= ksum }
+        // Horizontal pass
+        var tmp = [Float](repeating: 0, count: W * H)
+        for y in 0..<H {
+            let row = y * W
+            for x in 0..<W {
+                var s: Float = 0
+                for k in -radius...radius {
+                    let xi = min(max(x + k, 0), W - 1)
+                    s += src[row + xi] * kernel[k + radius]
+                }
+                tmp[row + x] = s
+            }
+        }
+        // Vertical pass
+        var dst = [Float](repeating: 0, count: W * H)
+        for y in 0..<H {
+            let row = y * W
+            for x in 0..<W {
+                var s: Float = 0
+                for k in -radius...radius {
+                    let yi = min(max(y + k, 0), H - 1)
+                    s += tmp[yi * W + x] * kernel[k + radius]
+                }
+                dst[row + x] = s
+            }
+        }
+        return dst
+    }
+
+    // MARK: - Soft rectangle mask (port of light-avatar/core/utils/get_mask.py)
+
+    /// Direct port of Ditto / light-avatar's get_mask. W×H float32, inner
+    /// rect (ratio_w · ratio_h) is solid 1.0, the outer border is a
+    /// radial-distance feather to 0. The mask is centered at the crop's
+    /// geometric center (W/2, H/2) — same as the reference implementation.
+    static func buildCropMaskF32(W: Int, H: Int, ratioW: Double = 0.9, ratioH: Double = 0.9) -> [Float] {
+        let w = Int(Double(W) * ratioW)
+        let h = Int(Double(H) * ratioH)
+        let x1 = (W - w) / 2, x2 = x1 + w
+        let y1 = (H - h) / 2, y2 = y1 + h
+        var mask = [Float](repeating: 0, count: W * H)
+        // Inner rect: solid 1
+        for y in y1..<y2 {
+            let row = y * W
+            for x in x1..<x2 { mask[row + x] = 1.0 }
+        }
+        // Top edge (y in [0, y1), x in [x1, x2)): vertical fade 0→1
+        for y in 0..<y1 {
+            let v = Float(y) / Float(max(1, y1 - 1))
+            let row = y * W
+            for x in x1..<x2 { mask[row + x] = v }
+        }
+        let denBot = max(1, H - y2 - 1)
+        for y in y2..<H {
+            let v = Float(H - 1 - y) / Float(denBot)
+            let row = y * W
+            for x in x1..<x2 { mask[row + x] = v }
+        }
+        for x in 0..<x1 {
+            let v = Float(x) / Float(max(1, x1 - 1))
+            for y in y1..<y2 { mask[y * W + x] = v }
+        }
+        let denRight = max(1, W - x2 - 1)
+        for x in x2..<W {
+            let v = Float(W - 1 - x) / Float(denRight)
+            for y in y1..<y2 { mask[y * W + x] = v }
+        }
+        // Corners — radial fade from 1 at the inner corner to 0 at the outer.
+        for y in 0..<y1 {
+            for x in 0..<x1 {
+                let dx = Float(x1 - 1 - x) / Float(max(1, x1 - 1))
+                let dy = Float(y1 - 1 - y) / Float(max(1, y1 - 1))
+                let r = (dx * dx + dy * dy).squareRoot()
+                mask[y * W + x] = max(0, 1 - min(1, r))
+            }
+        }
+        for y in 0..<y1 {
+            for x in x2..<W {
+                let dx = Float(x - x2) / Float(denRight)
+                let dy = Float(y1 - 1 - y) / Float(max(1, y1 - 1))
+                let r = (dx * dx + dy * dy).squareRoot()
+                mask[y * W + x] = max(0, 1 - min(1, r))
+            }
+        }
+        for y in y2..<H {
+            for x in 0..<x1 {
+                let dx = Float(x1 - 1 - x) / Float(max(1, x1 - 1))
+                let dy = Float(y - y2) / Float(denBot)
+                let r = (dx * dx + dy * dy).squareRoot()
+                mask[y * W + x] = max(0, 1 - min(1, r))
+            }
+        }
+        for y in y2..<H {
+            for x in x2..<W {
+                let dx = Float(x - x2) / Float(denRight)
+                let dy = Float(y - y2) / Float(denBot)
+                let r = (dx * dx + dy * dy).squareRoot()
+                mask[y * W + x] = max(0, 1 - min(1, r))
+            }
+        }
+        return mask
+    }
+
+    // MARK: - vImage warp helpers
+
+    /// Warp an ARGB8888 byte buffer by a 2D affine using vImage Lanczos.
+    /// `affine` is the destination→source map (vImage convention).
+    @discardableResult
+    private static func vImageWarpARGB(
+        src: UnsafeMutableRawPointer, srcW: Int, srcH: Int, srcBPR: Int,
+        dst: UnsafeMutableRawPointer, dstW: Int, dstH: Int, dstBPR: Int,
+        affine: Affine2D
+    ) -> Int {
+        var s = vImage_Buffer(data: src, height: vImagePixelCount(srcH),
+                              width: vImagePixelCount(srcW), rowBytes: srcBPR)
+        var d = vImage_Buffer(data: dst, height: vImagePixelCount(dstH),
+                              width: vImagePixelCount(dstW), rowBytes: dstBPR)
+        var transform = vImage_AffineTransform_Double(
+            a:  affine.a, b: affine.b,
+            c:  affine.c, d: affine.d,
+            tx: affine.tx, ty: affine.ty
+        )
+        var bg: UInt32 = 0
+        let flags = vImage_Flags(kvImageHighQualityResampling | kvImageBackgroundColorFill)
+        return Int(vImageAffineWarpD_ARGB8888(&s, &d, nil, &transform, &bg, flags))
+    }
+
+    @discardableResult
+    private static func vImageWarpFloat(
+        src: UnsafeMutableRawPointer, srcW: Int, srcH: Int, srcBPR: Int,
+        dst: UnsafeMutableRawPointer, dstW: Int, dstH: Int, dstBPR: Int,
+        affine: Affine2D
+    ) -> Int {
+        var s = vImage_Buffer(data: src, height: vImagePixelCount(srcH),
+                              width: vImagePixelCount(srcW), rowBytes: srcBPR)
+        var d = vImage_Buffer(data: dst, height: vImagePixelCount(dstH),
+                              width: vImagePixelCount(dstW), rowBytes: dstBPR)
+        var transform = vImage_AffineTransform_Double(
+            a:  affine.a, b: affine.b,
+            c:  affine.c, d: affine.d,
+            tx: affine.tx, ty: affine.ty
+        )
+        let bg: Float = 0
+        let flags = vImage_Flags(kvImageHighQualityResampling | kvImageBackgroundColorFill)
+        return Int(vImageAffineWarpD_PlanarF(&s, &d, nil, &transform, bg, flags))
+    }
+
+    private static func renderBGRA(_ cg: CGImage, w: Int, h: Int) -> ([UInt8], Int)? {
+        let bytesPerRow = w * 4
+        var bytes = [UInt8](repeating: 0, count: h * bytesPerRow)
+        let space = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedFirst.rawValue
+            | CGBitmapInfo.byteOrder32Little.rawValue
+        let ok: Bool = bytes.withUnsafeMutableBytes { buf in
+            guard let ctx = CGContext(
+                data: buf.baseAddress, width: w, height: h,
+                bitsPerComponent: 8, bytesPerRow: bytesPerRow,
+                space: space, bitmapInfo: bitmapInfo
+            ) else { return false }
+            ctx.interpolationQuality = .high
+            ctx.draw(cg, in: CGRect(x: 0, y: 0, width: w, height: h))
+            return true
+        }
+        return ok ? (bytes, bytesPerRow) : nil
+    }
+
+    // MARK: - Plan
+
+    struct PutbackPlan {
+        let outWidth: Int
+        let outHeight: Int
+        let canvasFrames: [[UInt8]]
+        let canvasFPS: Double
+        let bytesPerRow: Int
+        /// Per-canvas-frame face crop params (smoothed). count == canvasFrames.count.
+        let paramsPerFrame: [FaceCropParams]
+        /// Per-canvas-frame DRIVER face polygon vertices (canvas pixel
+        /// coords, top-left origin). count == canvasFrames.count.
+        /// Used to build a face-shaped mask per output frame so only the
+        /// face skin gets engine pixels — hair/neck/background pass
+        /// through unchanged from the driver.
+        let driverFacePolygonPerFrame: [[CGPoint]]
+        /// First-frame RAW params (no smoothing). The engine processed the
+        /// first frame's RAW Vision face rect to compute its internal
+        /// M_o2c; we need the same raw values for an exact match.
+        let firstFrameRawParams: FaceCropParams
+        /// Engine's face anchor in the 384 crop, computed exactly from
+        /// the first frame's faceW/faceH ratio:
+        ///   anchor_y = 192 + (384·0.20/1.8) · (faceH_first / max(faceW_first, faceH_first))
+        /// This deviates from the hardcoded 234.67 when the first frame's
+        /// face rect isn't perfectly square.
+        let engineFaceAnchorY: Double
+        /// Static crop-space mask. ENGINE_CROP_SIZE×ENGINE_CROP_SIZE float [0,1].
+        /// LEGACY: kept for static-portrait mode (no driver per-frame
+        /// landmarks). Driver mode uses `driverFacePolygonPerFrame` instead.
+        let cropMask: [Float]
+        let cropMaskSize: Int
+    }
+
+    // ----------------------------------------------------------------
+    // Bithuman Expression engine constants — must mirror the values in
+    // bitHumanKit/Sources/Expression/ML/Rendering/ImagePreprocess.swift
+    // faceAwareCropRect() and the engine's 384×384 output resolution.
+    // ----------------------------------------------------------------
+
+    /// Engine output canvas size (resampled to from `contextSide`).
+    static let engineCropSize: Int = 384
+
+    /// `contextSide = max(faceW, faceH) * engineContextScale`
+    static let engineContextScale: Double = 1.8
+
+    /// `yNudge = engineYNudgeRatio * faceH`  (shifts crop top-left up
+    /// when negative, putting more forehead/hair in the crop).
+    static let engineYNudgeRatio: Double = -0.20
+
+    /// Theoretical engine face anchor in the 384 crop, derived analytically
+    /// from the first frame's Vision face W and H using the SDK's exact
+    /// formula. This is the FIRST-FRAME baseline — the actual engine
+    /// output drifts from this per frame due to animation (mouth opening
+    /// etc.). For per-frame alignment, use `detectFaceCenterInCrop` on
+    /// each engine output and smooth across frames; this baseline is only
+    /// used as a fallback when detection fails.
+    static func engineFaceAnchor(faceW: Double, faceH: Double) -> CGPoint {
+        let half = Double(engineCropSize) / 2.0
+        let s = Double(engineCropSize) / (engineContextScale * max(faceW, faceH))
+        let shift = s * (-engineYNudgeRatio) * faceH
+        return CGPoint(x: half, y: half + shift)
+    }
+
+    /// Per-frame face pose detected via Vision landmarks. Center is in
+    /// top-left pixel coords. Angle is the eye-mid → mouth-mid axis tilt
+    /// (radians, same convention as parseRectFromLandmarks). Used on the
+    /// engine output AND driver frames for per-frame alignment without
+    /// any first-frame baked-in reference.
+    struct FacePose {
+        var center: CGPoint
+        var angle: Double
+    }
+
+    /// Detect face center + angle on any frame (engine output or driver).
+    /// Uses Vision face landmarks for both — the center is the face-rect
+    /// midpoint (matches the engine's identity setup convention) and the
+    /// angle is derived from eye_mid → mouth_mid axis (same convention as
+    /// the driver-side params).
+    static func detectFacePose(cg: CGImage) -> FacePose? {
+        let req = VNDetectFaceLandmarksRequest()
+        let handler = VNImageRequestHandler(cgImage: cg, options: [:])
+        do { try handler.perform([req]) } catch { return nil }
+        guard let faces = req.results, !faces.isEmpty else { return nil }
+        let face = faces.max {
+            $0.boundingBox.width * $0.boundingBox.height
+                < $1.boundingBox.width * $1.boundingBox.height
+        }!
+        let imgSize = CGSize(width: cg.width, height: cg.height)
+        let bb = face.boundingBox
+        // Center: face bbox midpoint in top-left pixel coords.
+        let cx = (bb.origin.x + bb.width / 2) * imgSize.width
+        let cy = (1.0 - bb.origin.y - bb.height / 2) * imgSize.height
+        // Angle: from eye-mid → mouth-mid axis (same as paramsFromFaceRect).
+        let (eyeMid, mouthMid) = extractAxisAnchors(landmarks: face.landmarks, imgSize: imgSize)
+        var angle = 0.0
+        if let e = eyeMid, let m = mouthMid {
+            let dx = Double(m.x - e.x), dy = Double(m.y - e.y)
+            let l = (dx * dx + dy * dy).squareRoot()
+            if l > 1e-3 {
+                let uyx = dx / l, uyy = dy / l
+                let uxx = uyy
+                let uxy = -uyx
+                var a = acos(max(-1.0, min(1.0, uxx)))
+                if uxy < 0 { a = -a }
+                angle = a
+            }
+        }
+        return FacePose(center: CGPoint(x: cx, y: cy), angle: angle)
+    }
+
+    /// Convenience: detect just the face center (no angle), faster than
+    /// `detectFacePose` because it uses face-rectangle detection only.
+    /// Kept for callers that don't need angle.
+    static func detectFaceCenterInCrop(cg: CGImage) -> CGPoint? {
+        return detectFacePose(cg: cg)?.center
+    }
+
+    /// Smooth a [FacePose?] series independently per axis + angle.
+    static func smoothPoses(_ raw: [FacePose?], sigma: Double = 3.0) -> [FacePose] {
+        let n = raw.count
+        guard n > 0 else { return [] }
+        let centers = raw.map { $0?.center }
+        let angles  = raw.map { $0?.angle  }
+        let smoothCenters = smoothPoints(centers, sigma: sigma)
+        // Smooth angles with same interp + Gaussian pipeline
+        let valid = (0..<n).filter { angles[$0] != nil }
+        let firstA = valid.first.map { angles[$0]! } ?? 0
+        let lastA  = valid.last.map { angles[$0]! } ?? 0
+        var filledA = [Double]()
+        var nextValid = 0
+        for i in 0..<n {
+            if let a = angles[i] {
+                filledA.append(a)
+                while nextValid < valid.count && valid[nextValid] <= i { nextValid += 1 }
+            } else if valid.isEmpty {
+                filledA.append(0)
+            } else if i < valid.first! {
+                filledA.append(firstA)
+            } else if i > valid.last! {
+                filledA.append(lastA)
+            } else {
+                let lo = valid[nextValid - 1], hi = valid[nextValid]
+                let t = Double(i - lo) / Double(hi - lo)
+                filledA.append(angles[lo]! + (angles[hi]! - angles[lo]!) * t)
+            }
+        }
+        let smoothA = gaussianSmooth(filledA, sigma: sigma)
+        return (0..<n).map { FacePose(center: smoothCenters[$0], angle: smoothA[$0]) }
+    }
+
+    /// Temporal smoothing for a [CGPoint?] series — linear interp for nils
+    /// then Gaussian smooth each axis.
+    static func smoothPoints(_ raw: [CGPoint?], sigma: Double = 5.0) -> [CGPoint] {
+        let n = raw.count
+        guard n > 0 else { return [] }
+        let valid = (0..<n).filter { raw[$0] != nil }
+        guard !valid.isEmpty else { return Array(repeating: .zero, count: n) }
+        // Fill nils with nearest valid (linear interp on interior gaps)
+        var filled: [CGPoint] = []
+        filled.reserveCapacity(n)
+        let firstValid = raw[valid.first!]!
+        let lastValid = raw[valid.last!]!
+        var nextValidIdx = 0
+        for i in 0..<n {
+            if let p = raw[i] {
+                filled.append(p)
+                while nextValidIdx < valid.count && valid[nextValidIdx] <= i { nextValidIdx += 1 }
+            } else if i < valid.first! {
+                filled.append(firstValid)
+            } else if i > valid.last! {
+                filled.append(lastValid)
+            } else {
+                // Interp between previous valid (valid[nextValidIdx - 1])
+                // and next valid (valid[nextValidIdx]).
+                let lo = valid[nextValidIdx - 1], hi = valid[nextValidIdx]
+                let a = raw[lo]!, b = raw[hi]!
+                let t = CGFloat(Double(i - lo) / Double(hi - lo))
+                filled.append(CGPoint(x: a.x + (b.x - a.x) * t,
+                                       y: a.y + (b.y - a.y) * t))
+            }
+        }
+        let xs = filled.map { Double($0.x) }
+        let ys = filled.map { Double($0.y) }
+        let sx = gaussianSmooth(xs, sigma: sigma)
+        let sy = gaussianSmooth(ys, sigma: sigma)
+        return (0..<n).map { CGPoint(x: sx[$0], y: sy[$0]) }
+    }
+
+    static func makePlan(portraitURL: URL) throws -> PutbackPlan {
+        guard let src = CGImageSourceCreateWithURL(portraitURL as CFURL, nil),
+              let cg = CGImageSourceCreateImageAtIndex(src, 0, nil)
+        else { throw CompareError.cli("could not decode portrait: \(portraitURL.path)") }
+        guard let (sourceBytes, bpr) = renderBGRA(cg, w: cg.width, h: cg.height) else {
+            throw CompareError.cli("source portrait render failed")
+        }
+        let imgSize = CGSize(width: cg.width, height: cg.height)
+        // Run a single landmark request so we get both the face bbox
+        // (for engine-matching crop sizing) and eye/mouth centroids
+        // (for the rotation).
+        let req = VNDetectFaceLandmarksRequest()
+        try? VNImageRequestHandler(cgImage: cg, options: [:]).perform([req])
+        guard let face = req.results?.max(by: {
+            $0.boundingBox.width * $0.boundingBox.height
+                < $1.boundingBox.width * $1.boundingBox.height
+        }) else {
+            throw CompareError.cli("no face detected in portrait")
+        }
+        let faceRect = visionBBoxToPixelRect(face.boundingBox, imgSize: imgSize)
+        let (eyeMid, mouthMid) = extractAxisAnchors(landmarks: face.landmarks, imgSize: imgSize)
+        let params = paramsFromFaceRect(faceRect: faceRect, eyeMid: eyeMid, mouthMid: mouthMid)
+        let mask = buildCropMaskF32(W: engineCropSize, H: engineCropSize)
+        // For a static portrait there's only one frame, so smoothed[0] == raw.
+        let anchor = engineFaceAnchor(faceW: params.faceW, faceH: params.faceH)
+        // Face polygon (chin → temples → forehead arc) for canvas-coords
+        // mask. Empty array = fallback to legacy crop-warp mask.
+        let polygon = extractFacePolygon(cg: cg) ?? []
+        return PutbackPlan(
+            outWidth: cg.width, outHeight: cg.height,
+            canvasFrames: [sourceBytes],
+            canvasFPS: 25.0,
+            bytesPerRow: bpr,
+            paramsPerFrame: [params],
+            driverFacePolygonPerFrame: [polygon],
+            firstFrameRawParams: params,
+            engineFaceAnchorY: Double(anchor.y),
+            cropMask: mask,
+            cropMaskSize: engineCropSize
+        )
+    }
+
+    static func firstFrame(of url: URL) throws -> CGImage {
+        let asset = AVURLAsset(url: url)
+        let gen = AVAssetImageGenerator(asset: asset)
+        gen.appliesPreferredTrackTransform = true
+        gen.requestedTimeToleranceBefore = .zero
+        gen.requestedTimeToleranceAfter = .zero
+        do { return try gen.copyCGImage(at: .zero, actualTime: nil) }
+        catch { throw CompareError.cli("could not extract first frame from \(url.path): \(error)") }
+    }
+
+    static func makeDriverPlan(driverURL: URL) throws -> PutbackPlan {
+        let asset = AVURLAsset(url: driverURL)
+        let semaphore = DispatchSemaphore(value: 0)
+        var loadedTrack: AVAssetTrack?
+        var loadedFPS: Double = 24.0
+        var loadErr: Error?
+        Task {
+            do {
+                let tracks = try await asset.loadTracks(withMediaType: .video)
+                if let t = tracks.first {
+                    let fps: Float = try await t.load(.nominalFrameRate)
+                    loadedFPS = Double(fps)
+                    loadedTrack = t
+                }
+            } catch { loadErr = error }
+            semaphore.signal()
+        }
+        semaphore.wait()
+        if let loadErr { throw CompareError.cli("driver track load failed: \(loadErr)") }
+        guard let track = loadedTrack else {
+            throw CompareError.cli("driver video has no video track: \(driverURL.path)")
+        }
+        let reader = try AVAssetReader(asset: asset)
+        let output = AVAssetReaderTrackOutput(track: track, outputSettings: [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+        ])
+        output.alwaysCopiesSampleData = false
+        reader.add(output)
+        guard reader.startReading() else {
+            throw CompareError.cli("AVAssetReader startReading failed")
+        }
+
+        var frames: [[UInt8]] = []
+        var rawParams: [FaceCropParams?] = []
+        var rawPolygons: [[CGPoint]] = []
+        var outW = 0, outH = 0, bytesPerRow = 0
+
+        while let sbuf = output.copyNextSampleBuffer() {
+            guard let pb = CMSampleBufferGetImageBuffer(sbuf) else { continue }
+            CVPixelBufferLockBaseAddress(pb, .readOnly)
+            let w = CVPixelBufferGetWidth(pb)
+            let h = CVPixelBufferGetHeight(pb)
+            let srcBPR = CVPixelBufferGetBytesPerRow(pb)
+            let base = CVPixelBufferGetBaseAddress(pb)!
+            let tightBPR = w * 4
+            var buf = [UInt8](repeating: 0, count: h * tightBPR)
+            buf.withUnsafeMutableBytes { dst in
+                for y in 0..<h {
+                    memcpy(dst.baseAddress!.advanced(by: y * tightBPR),
+                           base.advanced(by: y * srcBPR), tightBPR)
+                }
+            }
+            // Detect face + landmarks directly on the pb (no CGImage roundtrip).
+            let req = VNDetectFaceLandmarksRequest()
+            try? VNImageRequestHandler(cvPixelBuffer: pb, options: [:]).perform([req])
+            let imgSize = CGSize(width: w, height: h)
+            var params: FaceCropParams? = nil
+            var polygon: [CGPoint] = []
+            if let face = req.results?.max(by: {
+                $0.boundingBox.width * $0.boundingBox.height
+                    < $1.boundingBox.width * $1.boundingBox.height
+            }) {
+                let faceRect = visionBBoxToPixelRect(face.boundingBox, imgSize: imgSize)
+                let (eyeMid, mouthMid) = extractAxisAnchors(landmarks: face.landmarks, imgSize: imgSize)
+                params = paramsFromFaceRect(faceRect: faceRect, eyeMid: eyeMid, mouthMid: mouthMid)
+                // Build face polygon from the SAME landmark detection.
+                if let lm = face.landmarks {
+                    let H = imgSize.height
+                    func ptsTL(_ r: VNFaceLandmarkRegion2D?) -> [CGPoint] {
+                        guard let r = r else { return [] }
+                        return r.pointsInImage(imageSize: imgSize).map { CGPoint(x: $0.x, y: H - $0.y) }
+                    }
+                    polygon = facePolygonFromRegions(
+                        faceContour: ptsTL(lm.faceContour),
+                        leftEyebrow: ptsTL(lm.leftEyebrow),
+                        rightEyebrow: ptsTL(lm.rightEyebrow),
+                        leftEye: ptsTL(lm.leftEye),
+                        rightEye: ptsTL(lm.rightEye)
+                    ) ?? []
+                }
+            }
+            CVPixelBufferUnlockBaseAddress(pb, .readOnly)
+            if outW == 0 { outW = w; outH = h; bytesPerRow = tightBPR }
+            frames.append(buf)
+            rawParams.append(params)
+            rawPolygons.append(polygon)
+        }
+        if reader.status == .failed {
+            throw CompareError.cli("AVAssetReader read failed: \(reader.error?.localizedDescription ?? "unknown")")
+        }
+        guard !frames.isEmpty else { throw CompareError.cli("driver yielded zero frames") }
+        let det = rawParams.compactMap { $0 }.count
+        FileHandle.standardError.write(Data(
+            "[Putback] driver: \(frames.count) frames, \(det) landmark detections, FPS \(loadedFPS)\n".utf8
+        ))
+        let smoothed = smoothParams(rawParams)
+        let mask = buildCropMaskF32(W: engineCropSize, H: engineCropSize)
+        // Engine processed the RAW first frame's Vision face rect for the
+        // identity crop — for an exact putback alignment match, we use
+        // the RAW (not smoothed) first-frame params to compute the
+        // engine's face anchor and the rotation reference.
+        let firstRaw = rawParams.first(where: { $0 != nil }) ??
+                       FaceCropParams(centerX: 0, centerY: 0, size: 1, angle: 0,
+                                       faceW: 1, faceH: 1)
+        let unwrapped = firstRaw!
+        let anchor = engineFaceAnchor(faceW: unwrapped.faceW, faceH: unwrapped.faceH)
+        return PutbackPlan(
+            outWidth: outW, outHeight: outH,
+            canvasFrames: frames,
+            canvasFPS: loadedFPS > 0 ? loadedFPS : 24.0,
+            bytesPerRow: bytesPerRow,
+            paramsPerFrame: smoothed,
+            driverFacePolygonPerFrame: rawPolygons,
+            firstFrameRawParams: unwrapped,
+            engineFaceAnchorY: Double(anchor.y),
+            cropMask: mask,
+            cropMaskSize: engineCropSize
+        )
+    }
+
+    // MARK: - Per-frame compositor (Ditto-exact)
+
+    /// 1. Compute M_c2o (crop→original) from this frame's smoothed params.
+    /// 2. vImageAffineWarpD_ARGB8888 on engine BGRA → warped BGRA canvas.
+    /// 3. vImageAffineWarpD_PlanarF on the crop mask → warped float mask canvas.
+    /// 4. Per-pixel blend: result = m * warped_render + (1 - m) * driver.
+    static func compositeFrame(
+        plan: PutbackPlan, animatedFace: CGImage, frameIndex: Int,
+        engineAnchorOverride: CGPoint? = nil,
+        engineAngleOverride: Double? = nil
+    ) -> CGImage? {
+        // Pick canvas frame + face params via FPS rate-map.
+        let canvasIdx: Int
+        if plan.canvasFrames.count == 1 {
+            canvasIdx = 0
+        } else {
+            let mapped = Int((Double(frameIndex) * plan.canvasFPS / 25.0).rounded(.down))
+            canvasIdx = min(mapped, plan.canvasFrames.count - 1)
+        }
+        let params = plan.paramsPerFrame[canvasIdx]
+        let outW = plan.outWidth, outH = plan.outHeight
+        let bpr = plan.bytesPerRow
+        let dsize = Double(plan.cropMaskSize)
+
+        // Per-frame relative rotation: prefer engine_angle DETECTED on
+        // this engine output frame (rather than first-frame-baked angle).
+        // If detection unavailable, fall back to the first-frame raw
+        // angle as a baseline.
+        let engineAngle = engineAngleOverride ?? plan.firstFrameRawParams.angle
+        let relParams = FaceCropParams(
+            centerX: params.centerX,
+            centerY: params.centerY,
+            size: params.size,
+            angle: params.angle - engineAngle,
+            faceW: params.faceW,
+            faceH: params.faceH
+        )
+        // Per-frame engine face anchor (detected via Vision per engine
+        // 384 output frame). Falls back to first-frame analytical anchor.
+        let targetCenter = engineAnchorOverride
+            ?? CGPoint(x: dsize / 2, y: plan.engineFaceAnchorY)
+        let m_o2c = buildM_o2c(params: relParams, dsize: dsize, targetCenter: targetCenter)
+        // For each canvas pixel (px, py), we want the corresponding
+        // crop pixel via M_o2c.apply((px, py)). Bilinear sample both
+        // engine and mask at that crop coord, then alpha-blend.
+        if frameIndex == 0 {
+            let probe = m_o2c.apply(CGPoint(x: params.centerX, y: params.centerY))
+            FileHandle.standardError.write(Data(String(format:
+                "[Putback] f0 params: center=(%.0f,%.0f) size=%.0f angle=%.2f°  M_o2c face_center→crop=(%.1f,%.1f) [expect (%.1f,%.1f)]\n",
+                params.centerX, params.centerY, params.size, params.angle * 180 / .pi,
+                probe.x, probe.y, targetCenter.x, targetCenter.y
+            ).utf8))
+        }
+
+        // Render engine to a 384×384 BGRA tight buffer for bilinear sampling.
+        guard let (engineBytes, eBPR) = renderBGRA(animatedFace,
+                                                   w: plan.cropMaskSize,
+                                                   h: plan.cropMaskSize) else { return nil }
+        let cropSize = plan.cropMaskSize
+        let cropMaxX = Double(cropSize - 1)
+        let cropMaxY = Double(cropSize - 1)
+
+        var canvas = plan.canvasFrames[canvasIdx]
+        let map = m_o2c   // canvas (px, py) → crop (cx, cy)
+
+        // FACE-POLYGON MASK PATH: if a non-empty face polygon is stored
+        // for this frame, rasterize it into a canvas-coords float mask
+        // and use that for the alpha blend. The mask shape follows the
+        // driver's actual face boundary — no rectangle, no hair/neck
+        // leakage. Inside the polygon, engine pixels visible; outside,
+        // driver passes through. Feathered edge softens the seam.
+        let driverPolygon = plan.driverFacePolygonPerFrame[canvasIdx]
+        let useFacePolygon = driverPolygon.count >= 3
+        let polygonMask: [Float]? = useFacePolygon
+            ? rasterizeFacePolygonMask(polygon: driverPolygon, W: outW, H: outH, featherSigma: 12.0)
+            : nil
+
+        canvas.withUnsafeMutableBufferPointer { dst in
+            engineBytes.withUnsafeBufferPointer { eb in
+                plan.cropMask.withUnsafeBufferPointer { cropMb in
+                    for py in 0..<outH {
+                        let pyD = Double(py)
+                        let dstRow = py * bpr
+                        for px in 0..<outW {
+                            let pxD = Double(px)
+                            let cx = map.a * pxD + map.b * pyD + map.tx
+                            let cy = map.c * pxD + map.d * pyD + map.ty
+                            if cx < 0 || cy < 0 || cx >= cropMaxX || cy >= cropMaxY { continue }
+
+                            let ix = Int(cx.rounded(.down))
+                            let iy = Int(cy.rounded(.down))
+                            let fx = cx - Double(ix)
+                            let fy = cy - Double(iy)
+                            let w00 = (1 - fx) * (1 - fy)
+                            let w10 = fx * (1 - fy)
+                            let w01 = (1 - fx) * fy
+                            let w11 = fx * fy
+
+                            // Alpha selection: face polygon mask in canvas
+                            // coords (preferred), else legacy crop-warp mask.
+                            let alpha: Double
+                            if let pm = polygonMask {
+                                alpha = Double(pm[py * outW + px])
+                            } else {
+                                let m00 = Double(cropMb[iy * cropSize + ix])
+                                let m10 = Double(cropMb[iy * cropSize + (ix + 1)])
+                                let m01 = Double(cropMb[(iy + 1) * cropSize + ix])
+                                let m11 = Double(cropMb[(iy + 1) * cropSize + (ix + 1)])
+                                alpha = w00 * m00 + w10 * m10 + w01 * m01 + w11 * m11
+                            }
+                            if alpha <= 0.001 { continue }
+                            let alphaC = max(0.0, min(1.0, alpha))
+                            let oneMinus = 1.0 - alphaC
+
+                            // Bilinear sample engine BGRA.
+                            let o00 = iy * eBPR + ix * 4
+                            let o10 = o00 + 4
+                            let o01 = o00 + eBPR
+                            let o11 = o01 + 4
+                            let dOff = dstRow + px * 4
+                            for c in 0...2 {
+                                let s = w00 * Double(eb[o00 + c])
+                                      + w10 * Double(eb[o10 + c])
+                                      + w01 * Double(eb[o01 + c])
+                                      + w11 * Double(eb[o11 + c])
+                                let dCur = Double(dst[dOff + c])
+                                let blended = alphaC * s + oneMinus * dCur
+                                dst[dOff + c] = UInt8(max(0, min(255, blended.rounded())))
+                            }
+                            dst[dOff + 3] = 255
+                        }
+                    }
+                }
+            }
+        }
+
+        let space = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedFirst.rawValue
+            | CGBitmapInfo.byteOrder32Little.rawValue
+        let provider = CGDataProvider(data: NSData(bytes: canvas, length: canvas.count))!
+        return CGImage(
+            width: outW, height: outH,
+            bitsPerComponent: 8, bitsPerPixel: 32,
+            bytesPerRow: bpr, space: space,
+            bitmapInfo: CGBitmapInfo(rawValue: bitmapInfo),
+            provider: provider, decode: nil, shouldInterpolate: false,
+            intent: .defaultIntent
+        )
+    }
+}
+
+// MARK: - Aliases so CompareDiT still compiles
+
+typealias PutbackPlan = Putback.PutbackPlan

--- a/Examples/swift/compare-llm/Package.swift
+++ b/Examples/swift/compare-llm/Package.swift
@@ -1,0 +1,38 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+// CompareLLM — load each on-device LLM choice (iOS vs macOS split) and
+// run a fixed avatar-style prompt set, to sanity-check the model split
+// from a Mac before shipping.
+//
+// This tool does NOT depend on any bitHuman binary framework: it talks
+// to the same upstream OSS packages (mlx-swift-lm, swift-transformers,
+// swift-huggingface) that bitHumanKit's LLMClient is built on, with the
+// same load/generate path. Pins mirror swift/Package.swift in the
+// private monorepo so what we measure here is what ships. See README.md.
+let package = Package(
+    name: "CompareLLM",
+    platforms: [
+        .macOS("26.0")
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ml-explore/mlx-swift-lm", from: "3.31.3"),
+        .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.0"),
+        .package(url: "https://github.com/huggingface/swift-huggingface", from: "0.9.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "CompareLLM",
+            dependencies: [
+                .product(name: "MLXLLM", package: "mlx-swift-lm"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+                .product(name: "MLXHuggingFace", package: "mlx-swift-lm"),
+                .product(name: "Tokenizers", package: "swift-transformers"),
+                .product(name: "HuggingFace", package: "swift-huggingface"),
+            ],
+            path: "Sources/CompareLLM",
+            swiftSettings: [.swiftLanguageMode(.v5)]
+        )
+    ]
+)

--- a/Examples/swift/compare-llm/README.md
+++ b/Examples/swift/compare-llm/README.md
@@ -1,0 +1,27 @@
+# CompareLLM
+
+Load each on-device LLM choice (the iOS vs macOS model split) and run a
+fixed avatar-style prompt set, so the split can be sanity-checked from a
+Mac before shipping.
+
+This tool depends only on the upstream OSS packages that bitHumanKit's
+`LLMClient` is built on (`mlx-swift-lm`, `swift-transformers`,
+`swift-huggingface`) — no bitHuman binary framework — and uses the same
+load/generate path, so what you measure here is what ships.
+
+## Run
+
+```bash
+cd Examples/swift/compare-llm
+swift run -c release CompareLLM            # both models, all prompts
+swift run -c release CompareLLM --model ios    # iOS choice (Gemma 3 1B QAT)
+swift run -c release CompareLLM --model macos  # macOS choice (Gemma 3n E2B)
+```
+
+Models download into `~/.cache/huggingface/hub` on first run. Reports
+load time, generation time, and tokens/sec per model.
+
+## Requires
+
+- macOS 26+ (Tahoe), Apple Silicon
+- ~3–5 GB free disk for the model weights

--- a/Examples/swift/compare-llm/Sources/CompareLLM/CompareLLM.swift
+++ b/Examples/swift/compare-llm/Sources/CompareLLM/CompareLLM.swift
@@ -1,0 +1,133 @@
+// CompareLLM — load each LLM choice and run a fixed avatar-style
+// prompt set, so the iOS-vs-macOS LLM split can be sanity-checked
+// from a Mac. Mirrors LLMClient's load/install path (direct factory
+// call, same generation params) so what we measure here is what
+// ships in production.
+//
+// Usage:
+//   compare-llm                  # both models, 4 prompts
+//   compare-llm --model ios      # iOS choice only (Gemma 3 1B QAT)
+//   compare-llm --model macos    # macOS choice only (Gemma 3n E2B)
+
+import Foundation
+import MLXLLM
+import MLXLMCommon
+import MLXHuggingFace
+import Tokenizers
+import HuggingFace
+
+let avatarInstructions = """
+You are a friendly voice assistant inside a small avatar app. \
+Reply in 1-2 short sentences. Be warm, natural, conversational. \
+No bullet lists.
+"""
+
+let promptSet: [String] = [
+    "Hi! What can you do?",
+    "I just got back from a long day at work. Any quick way to relax?",
+    "I am trying to learn Spanish. Can you teach me one useful phrase?",
+    "What's a fun fact about octopuses?",
+]
+
+enum Choice: String {
+    case ios, macos, both
+}
+
+private let helpText = """
+compare-llm — sanity-check the iOS-vs-macOS LLM split from a Mac.
+
+Loads each LLM choice (or both) and runs a fixed 4-prompt avatar-
+style prompt set, so what we measure here is what ships in production.
+
+Usage:
+  compare-llm                  # both models, 4 prompts
+  compare-llm --model ios      # iOS choice only (Gemma 3 1B QAT)
+  compare-llm --model macos    # macOS choice only (Gemma 3n E2B)
+  compare-llm -h | --help      # this help
+
+Models are downloaded into the standard ~/.cache/huggingface/hub
+cache on first run.
+"""
+
+func parseChoice() -> Choice {
+    let args = Array(CommandLine.arguments.dropFirst())
+    if args.contains("-h") || args.contains("--help") {
+        print(helpText)
+        exit(0)
+    }
+    var i = 0
+    while i < args.count {
+        if args[i] == "--model" || args[i] == "-m" {
+            guard i + 1 < args.count else { break }
+            return Choice(rawValue: args[i + 1].lowercased()) ?? .both
+        }
+        i += 1
+    }
+    return .both
+}
+
+func loadContainer(_ config: ModelConfiguration) async throws -> ModelContainer {
+    try await LLMModelFactory.shared.loadContainer(
+        from: #hubDownloader(),
+        using: #huggingFaceTokenizerLoader(),
+        configuration: config,
+        progressHandler: { progress in
+            let pct = Int(progress.fractionCompleted * 100)
+            if pct % 10 == 0 {
+                FileHandle.standardError.write(Data("  download: \(pct)%\r".utf8))
+            }
+        }
+    )
+}
+
+func runPrompts(label: String, container: ModelContainer) async {
+    let session = ChatSession(
+        container,
+        instructions: avatarInstructions,
+        generateParameters: GenerateParameters(
+            maxTokens: 300,
+            temperature: 0.7,
+            topP: 0.95,
+            repetitionPenalty: 1.1
+        )
+    )
+    print("\n=== \(label) ===\n")
+    for prompt in promptSet {
+        print("USER: \(prompt)")
+        let start = Date()
+        var response = ""
+        do {
+            for try await chunk in session.streamResponse(to: prompt) {
+                response += chunk
+            }
+        } catch {
+            print("BOT (error): \(error)")
+            continue
+        }
+        let elapsed = Date().timeIntervalSince(start)
+        print("BOT (\(String(format: "%.1f", elapsed))s): \(response.trimmingCharacters(in: .whitespacesAndNewlines))")
+        print("")
+    }
+}
+
+@main
+struct CompareLLM {
+    static func main() async {
+        let choice = parseChoice()
+        do {
+            if choice == .ios || choice == .both {
+                print("Loading iOS choice (Gemma 3 1B QAT 4-bit)…")
+                let c = try await loadContainer(LLMRegistry.gemma3_1B_qat_4bit)
+                await runPrompts(label: "iOS — Gemma 3 1B QAT 4-bit", container: c)
+            }
+            if choice == .macos || choice == .both {
+                print("Loading macOS choice (Gemma 3n E2B 4-bit)…")
+                let c = try await loadContainer(LLMRegistry.gemma4_e2b_it_4bit)
+                await runPrompts(label: "macOS — Gemma 3n E2B 4-bit", container: c)
+            }
+        } catch {
+            FileHandle.standardError.write(Data("error: \(error)\n".utf8))
+            exit(1)
+        }
+    }
+}

--- a/Examples/swift/compare-tts/Package.swift
+++ b/Examples/swift/compare-tts/Package.swift
@@ -1,0 +1,49 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+// CompareTTS — load each TTS backend (Kokoro, Qwen3-TTS) and synthesize
+// a fixed utterance, to sanity-check the vendored MLXAudioTTS path from
+// a Mac without a mic.
+//
+// PRIVATE-SOURCE DEPENDENCY: this tool imports `MLXAudioTTS`, which is
+// re-exported by the `Voice` product of the bithuman-sdk `voice/`
+// package (the vendored Blaizzy/mlx-audio-swift TTS stack). That stack
+// is NOT part of the public binary distribution, so this example cannot
+// build against the published SwiftPM package alone — it needs the
+// private monorepo `bithuman-product/bithuman-sdk` cloned as a SIBLING
+// of this repo:
+//
+//     ~/code/bithuman-sdk          (private; collaborator access)
+//     ~/code/bithuman-sdk-public   (this repo)
+//
+// The path dep below resolves voice/ via that sibling layout. External
+// developers without private access should use the `Voice` API through
+// the `bitHumanKit` umbrella binary instead of this dev harness. See
+// README.md.
+let package = Package(
+    name: "CompareTTS",
+    platforms: [
+        .macOS("26.0")
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ml-explore/mlx-swift", .upToNextMinor(from: "0.31.3")),
+        .package(url: "https://github.com/ml-explore/mlx-swift-lm", from: "3.31.3"),
+        // Private-source path dep — see the header note. Resolves the
+        // `voice/` SwiftPM package (product "Voice") via the sibling
+        // bithuman-sdk checkout.
+        .package(name: "voice", path: "../../../../bithuman-sdk/voice"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "CompareTTS",
+            dependencies: [
+                .product(name: "Voice", package: "voice"),
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+            ],
+            path: "Sources/CompareTTS",
+            swiftSettings: [.swiftLanguageMode(.v5)]
+        )
+    ]
+)

--- a/Examples/swift/compare-tts/README.md
+++ b/Examples/swift/compare-tts/README.md
@@ -1,0 +1,47 @@
+# CompareTTS
+
+Load each TTS backend and synthesize a fixed utterance, so the vendored
+`MLXAudioTTS` path can be sanity-checked from a Mac without a mic.
+
+Backends exercised:
+
+| Backend   | Repo                                          | Use      |
+|-----------|-----------------------------------------------|----------|
+| Kokoro    | `mlx-community/Kokoro-82M-4bit`               | preset   |
+| Qwen3-TTS | `mlx-community/Qwen3-TTS-12Hz-0.6B-Base-4bit` | cloning  |
+
+## Private-source dependency
+
+This example imports `MLXAudioTTS`, re-exported by the `Voice` product of
+the bithuman-sdk `voice/` package (the vendored
+[Blaizzy/mlx-audio-swift](https://github.com/Blaizzy/mlx-audio-swift) TTS
+stack, MIT). That stack is **not** part of the public binary
+distribution, so this dev harness can only build against the private
+monorepo. Clone it as a **sibling** of this repo:
+
+```
+~/code/bithuman-sdk          # private (collaborator access)
+~/code/bithuman-sdk-public   # this repo
+```
+
+The `Package.swift` path dep (`../../../../bithuman-sdk/voice`) resolves
+`voice/` via that layout.
+
+External developers without private access should reach the TTS stack
+through the published `bitHumanKit` umbrella binary instead of this tool.
+
+## Run
+
+```bash
+cd Examples/swift/compare-tts
+swift run -c release CompareTTS            # both backends
+swift run -c release CompareTTS --help
+```
+
+Models download into `~/.cache/huggingface/hub` on first run. Reports
+load time, gen time, RTF, |mean| and peak amplitude per backend.
+
+## Requires
+
+- macOS 26+ (Tahoe), Apple Silicon
+- The private bithuman-sdk sibling checkout (see above)

--- a/Examples/swift/compare-tts/Sources/CompareTTS/CompareTTS.swift
+++ b/Examples/swift/compare-tts/Sources/CompareTTS/CompareTTS.swift
@@ -1,0 +1,81 @@
+// Internal: load each TTS backend end-to-end and run a fixed
+// utterance, so the vendored MLXAudioTTS path can be sanity-
+// checked from a Mac without needing a mic / interactive shell.
+//
+// Sibling of CompareDiT (avatar) and CompareLLM (LLM).
+import Foundation
+@preconcurrency import MLX
+@preconcurrency import MLXAudioTTS
+@preconcurrency import MLXLMCommon
+
+private let helpText = """
+compare-tts — load each TTS backend end-to-end and run a fixed
+utterance, so the vendored MLXAudioTTS path can be sanity-checked
+from a Mac without needing a mic / interactive shell.
+
+Backends exercised:
+  Kokoro     mlx-community/Kokoro-82M-4bit         (preset voices)
+  Qwen3-TTS  mlx-community/Qwen3-TTS-12Hz-0.6B-Base-4bit  (cloning)
+
+Usage:
+  compare-tts            # run both backends
+  compare-tts -h | --help   # this help
+
+Models download into ~/.cache/huggingface/hub on first run. Reports
+load time, gen time, RTF, |mean| and peak amplitude per backend.
+"""
+
+@main
+struct CompareTTS {
+    static func main() async throws {
+        let args = Array(CommandLine.arguments.dropFirst())
+        if args.contains("-h") || args.contains("--help") {
+            print(helpText)
+            return
+        }
+        let text = "Hello, this is a smoke test of the vendored speech pipeline."
+        let cases: [(label: String, repo: String, voice: String?)] = [
+            ("Kokoro", "mlx-community/Kokoro-82M-4bit", "af_heart"),
+            ("Qwen3-TTS", "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-4bit", "Aiden"),
+        ]
+
+        var failed = 0
+        for c in cases {
+            let t0 = Date()
+            print("→ \(c.label) (\(c.repo))")
+            do {
+                let model = try await TTS.loadModel(modelRepo: c.repo)
+                let loadSec = Date().timeIntervalSince(t0)
+
+                let tGen = Date()
+                let pcm = try await model.generate(
+                    text: text,
+                    voice: c.voice,
+                    refAudio: nil,
+                    refText: nil,
+                    language: nil
+                )
+                let genSec = Date().timeIntervalSince(tGen)
+
+                let samples = pcm.size
+                let durationSec = Double(samples) / Double(model.sampleRate)
+                let absMean = MLX.mean(MLX.abs(pcm)).item(Float.self)
+                let peak = MLX.max(MLX.abs(pcm)).item(Float.self)
+                let rtf = genSec / max(durationSec, 0.001)
+                let ok = absMean > 0.001 && peak > 0.05 && durationSec > 0.5
+                print(String(format: "  load %.1fs · gen %.2fs · %d samples @ %d Hz = %.2fs · RTF %.2fx · |mean| %.4f peak %.3f · %@",
+                             loadSec, genSec, samples, model.sampleRate, durationSec, rtf, absMean, peak,
+                             ok ? "PASS" : "FAIL"))
+                if !ok { failed += 1 }
+            } catch {
+                print("  ERROR: \(error.localizedDescription)")
+                failed += 1
+            }
+        }
+        if failed > 0 {
+            print("\n\(failed)/\(cases.count) failed")
+            exit(1)
+        }
+        print("\nall \(cases.count) backends OK")
+    }
+}

--- a/Examples/swift/essence-server/ARCHITECTURE.md
+++ b/Examples/swift/essence-server/ARCHITECTURE.md
@@ -1,0 +1,261 @@
+# `essence-server` — architecture & operations
+
+A native Swift LiveKit avatar service. Drop-in replacement for the
+Python `essence-avatar` pool; runs as 8 launchd-supervised processes
+on a single Mac, uses the `bithuman-kit` Essence runtime for lipsync,
+and republishes both video AND audio in lockstep through LiveKit
+Cloud.
+
+This document is the top-level overview. For implementation details
+on a specific subsystem, see the source-file headers
+(`EssenceSession.swift`, `Config.swift`, `Metrics.swift`) and the
+`bithuman-product/bithuman-livekit-swift` fork's `MixerEngineObserver.swift`.
+
+## Deployment topology (moraga)
+
+```
+┌──── browser (any Tailscale-connected Mac) ────────────────────────┐
+│                                                                   │
+│   https://moraga.tail90843e.ts.net/A17AJJ8153?rendering_mode=cloud│
+│                                                                   │
+└────────────────────────┬──────────────────────────────────────────┘
+                         │ HTTPS via Tailscale Serve (port 443)
+                         ▼
+┌────────────── moraga (M4 Max, headless MBP) ──────────────────────┐
+│                                                                   │
+│   ┌─ agent-ui (Next.js dev) :3000 ──────────────────────────────┐ │
+│   │   /pages/[agentCode].tsx → mints LK token, dispatches       │ │
+│   │   `bithuman-swift-essence` agent                            │ │
+│   └──────────────────────────┬──────────────────────────────────┘ │
+│                              │                                    │
+│   ┌─ OrbStack containers ────┼──────────────────────────────────┐ │
+│   │  bithuman-agent (brain)  │ DataStreamAudioOutput            │ │
+│   │  livekit-dev             │   (no track; byte-stream         │ │
+│   │  bithuman-lb (nginx)     │    on lk.audio_stream topic)     │ │
+│   │  bithuman-auth           │                                  │ │
+│   └──────────────────────────┼──────────────────────────────────┘ │
+│                              │ POST /launch via nginx LB          │
+│                              ▼                                    │
+│   ┌─ essence-server pool (8 procs × 12 sessions = 96 cap) ──────┐ │
+│   │  ports 8089–8096                                            │ │
+│   │  LaunchAgents (per-user, ProcessType=Interactive, Nice=-10) │ │
+│   │  pmset -c powermode 2  (High Power Mode for full P-core    │ │
+│   │                          boost on this clamshell-closed MBP)│ │
+│   └────────────────────────────┬────────────────────────────────┘ │
+│                                │ LiveKit room as                  │
+│                                │ "bithuman-avatar-agent"           │
+└────────────────────────────────┼──────────────────────────────────┘
+                                 │
+                                 ▼
+                   ┌─── LiveKit Cloud (US Central) ───┐
+                   │   Routes WebRTC media P2P /      │
+                   │   via TURN; signals brain ↔      │
+                   │   avatar ↔ user                  │
+                   └──────────────────────────────────┘
+```
+
+**Why this shape?** moraga is a broken-display MBP M4 Max. macOS
+imposes a P-core power cap when the lid is closed without an
+external display, but `pmset -c powermode 2` overrides it (no
+display required). The brain runs in OrbStack so we keep the Linux
+deployment pathway working unchanged; only the avatar layer is
+Swift-native on the host. nginx is what bridges OrbStack-network
+agents into the host-network Swift pool via `host.docker.internal`.
+
+See `~/.claude/.../memory/project_moraga_pcore_throttle.md` for the
+hardware-config rationale.
+
+## Per-session pipeline (one room)
+
+```
+                     LiveKit Room
+                     ────────────
+brain (Python)                                    user (browser)
+─────────────                                     ──────────────
+DataStreamAudio                                   subscribes to
+   Output                                         avatar tracks
+      │                                                ▲
+      │ topic=lk.audio_stream                          │
+      │ (Int16 PCM, 24 kHz mono,                       │
+      │  paced ~10 chunks/s,                           │
+      │  caller=agent-AJ_*)                            │
+      ▼                                                │
+┌──────── essence-server (Swift, this repo) ──────────┴──────┐
+│                                                            │
+│   handleAudioByteStream                                    │
+│   ──────────────────────                                   │
+│   on first chunk: recordBrainIdentity(callerIdentity)      │
+│   per chunk:                                               │
+│     renderer.render(buf)  ──► EssenceRuntime.pushAudio     │
+│                                       │                    │
+│                                       │ resampled to 16    │
+│                                       │ kHz Int16 mono     │
+│                                       ▼                    │
+│   spawnFramePump (Task.detached, .userInitiated)           │
+│   ────────────────────────────                             │
+│   for await pair in runtime.framesWithAudio():             │
+│     # `pair` is one (CGImage, [Int16]) — the runtime's     │
+│     # 40 ms output: image AND the audio chunk that         │
+│     # produced it. Same wall-clock for both.               │
+│     ts = createTimeStampNs()                               │
+│     capturer.capture(pair.image,    timeStampNs=ts)        │
+│     mixer.capture(appAudio: pair.audioChunk)               │
+│                       │                                    │
+│                       ▼                                    │
+│   AVAudioEngine ──► WebRTC ADM (manual rendering mode,     │
+│                     no real audio device claim — see       │
+│                     fork's MixerEngineObserver)            │
+│                       │                                    │
+│                       ▼                                    │
+└────────────────  LocalAudioTrack + LocalVideoTrack  ───────┘
+                          │
+                          ▼
+                  user hears + sees in sync
+```
+
+**Sync invariant:** every audio chunk we publish on the avatar's
+audio track is the EXACT 40 ms slice the runtime processed for the
+paired video frame. There is no separate "feed brain audio directly
+to the audio track" path. The `framesWithAudio()` API is the only
+audio source. See `EssenceSession.swift` header for the rationale.
+
+## Components, by file
+
+### `Examples/EssenceServer/Sources/EssenceServer/`
+
+| File | Role |
+|---|---|
+| `main.swift` | HTTP server (Hummingbird), `/health`, `/ready`, `/status`, `/metrics`, `/launch` routes. Reads CLI flags + env vars into `EssenceServerConfig.shared`. |
+| `EssenceSession.swift` | One LiveKit-participant session. Owns the runtime, audio renderer, framepump, RPC handlers, lifecycle. The interesting code. |
+| `AudioRenderer.swift` | Bridge from a `RemoteAudioTrack` and the byte-stream handler into `runtime.pushAudio` (resampled to 16 kHz Int16). |
+| `Config.swift` | Central tunables (frame size, fps, idle threshold, max-sessions). Honors env-var overrides at startup. |
+| `Metrics.swift` | Process-wide counters; `/metrics` Prometheus text output. |
+| `FixtureCache.swift` | One `EssenceFixture` per `avatar_id`, shared across all sessions in a process (so JPEG decode happens once per fixture per process). |
+| `ModelStore.swift` | Resolves `avatar_id` → on-disk `.imx` path, downloading on cache miss. |
+
+### `Sources/bitHumanKit/Essence/` (the runtime)
+
+| File | Role |
+|---|---|
+| `EssenceRuntime.swift` | Public actor. `pushAudio` + `frames()` + `framesWithAudio()`. The pump runs at 25 fps internally; `framesWithAudio()` is what `essence-server` consumes. |
+| `EssenceGenerator.swift` | The actual lipsync inference (mel STFT → ONNX → KNN → frame composite). |
+| `MP4FrameReader.swift` | Loads and decodes the base video loop (the avatar's body / background). |
+| `PatchReader.swift` | Loads and serves lip patches (the mouth region inserts). |
+
+### Forked Swift LiveKit SDK
+
+`bithuman-product/bithuman-livekit-swift` (branch `main`, tracks upstream
+v2.14+) carries one patch:
+[`MixerEngineObserver.wireAppAudioPath()`](https://github.com/bithuman-product/bithuman-livekit-swift/tree/main/Sources/LiveKit/Audio/MixerEngineObserver.swift)
+— lets `mixer.capture(appAudio:)` work in manual rendering mode (no
+audio device claim). Without it, multi-process deployments can't
+publish audio: only one process at a time can hold the macOS audio
+device.
+
+Upstream PR: https://github.com/livekit/client-sdk-swift/pull/985.
+Drop the fork pin in `Package.swift` once it's merged.
+
+## Lifecycle & failure modes
+
+### Startup (per process, ~1 s)
+1. `main.swift` parses CLI + env, calls `EssenceServerConfig.applyEnv`.
+2. `AudioManager.setManualRenderingMode(true)` engages the no-device
+   audio path. If this fails, **all republished audio will be silent**
+   — `/ready` returns 503 in that case.
+3. Hummingbird starts on `--port` and serves `/health` immediately.
+4. `/launch` is gated on the registry capacity (`--max-sessions`).
+
+### Per session
+1. `/launch` → `SessionRegistry.reserve(room:)` (race-safe).
+2. `EssenceSession.start(url:, token:)` connects to the LK room as
+   `bithuman-avatar-agent`, calls `setMicrophone(enabled:true)`
+   (manual rendering = no real mic claim), publishes the video track.
+3. Bootstrap with 1 s of silence so the first frame is produced
+   before `publish()` awaits the dimensions completer.
+4. Brain opens an `lk.audio_stream` byte-stream targeted at the
+   avatar identity; per-chunk handler feeds the runtime.
+5. The framepump publishes paired `(image, audioChunk)` per emitted
+   runtime tick. RPCs (`lk.clear_buffer`, `lk.playback_finished`)
+   handle interruption + turn-end.
+6. When the room empties of real peers (no participants other than
+   `agent-AJ_*` dispatcher identities), the session self-stops with
+   `reason="room-empty"` and the slot is released.
+
+### Common failure-mode decoder
+
+| Symptom | Likely cause | Where to look |
+|---|---|---|
+| "Audio works, video lags by seconds" | Two parallel audio paths (legacy bug — fixed by `framesWithAudio()`) | `EssenceSession.swift` header |
+| "Mouth moves but no sound" | Audio queue cap < runtime audio buffer (legacy bug — runtime kept audio we discarded) | runtime's `audioBufferCapacity` vs any local queue |
+| "Avatar echoes user's voice" | `SessionAudioRenderer` attached to remote audio track + framepump publishing runtime output → user mic looped back | `handleSubscribedTrack` (must NOT attach renderer; documented inline) |
+| "Audio plays before video starts" | WebRTC video keyframe latency on subscribe; not an A/V bug. Try incognito mode (cached browser session can confuse) | browser-side |
+| "Many sessions but FPS drops" | (a) JPEG cache too small (pre-2026-05-05), (b) runtime hitting compute saturation. Check pool CPU and `aj_*` profile samples | `MP4FrameReader.jpegCap`, `sample` on a busy process |
+| "Can't launch new sessions, /launch returns 503" | Pool at-cap. `/status` shows `at_capacity=true` | scale up `--max-sessions` if hardware allows; raise the LB's retry budget |
+| "Sessions linger after browser close" | Was a bug pre-2026-05-05 (zombies until process restart). Now `participantDidDisconnect` → 1.5 s grace → self-stop | check `room-empty` log line in session log |
+
+## Operations
+
+### Quick references
+
+```bash
+# Deploy a code change end-to-end
+~/code/platform/deploy/macos/redeploy.sh
+
+# Re-deploy without rebuild (e.g. after just touching the plist)
+~/code/platform/deploy/macos/redeploy.sh --skip-build
+
+# Watch live pump-fps after deploy
+~/code/platform/deploy/macos/redeploy.sh --watch
+
+# Smoke test (single-session audio republish)
+~/code/platform/tools/bench/bench smoke
+
+# Capacity verification (current production cap)
+~/code/platform/tools/bench/bench stress 96
+
+# Per-process ceiling (hardware probe)
+~/code/platform/tools/bench/bench stress-one 16
+
+# Production mix (idle vs active)
+~/code/platform/tools/bench/bench mixed 128 64
+
+# Full e2e (brain dispatch through to user audio + video)
+~/code/platform/tools/bench/bench e2e
+
+# Read all per-instance metrics
+for p in 8089 8090 8091 8092 8093 8094 8095 8096; do
+    echo "--- :$p ---"
+    curl -s http://127.0.0.1:$p/metrics | grep '^essence_' | head -8
+done
+```
+
+### Tunable knobs (env vars at process start; see `Config.swift`)
+
+| Env var | Default | Effect |
+|---|---:|---|
+| `ESSENCE_FRAME_WIDTH` | 1280 | Output video width |
+| `ESSENCE_FRAME_HEIGHT` | 720 | Output video height |
+| `ESSENCE_FPS` | 25 | Target framerate (also drives audio chunk size) |
+| `ESSENCE_IDLE_SEC` | 0.8 | Playback monitor idle threshold |
+
+CLI: `--max-sessions N` (per-process cap; pool cap = N × 8 procs).
+
+### System-level requirements (set once on moraga)
+
+```bash
+sudo pmset -c powermode 2     # High Power Mode (essential — see memory note)
+sudo pmset -c disablesleep 1  # Don't sleep on AC
+```
+
+The LaunchAgent plist (`deploy/macos/com.bithuman.essence-server.template.plist`)
+also sets `ProcessType=Interactive` and `Nice=-10` so essence-server
+runs on P-cores at elevated priority over background daemons.
+
+## See also
+
+- Architectural rule for A/V sync in lipsync runtimes:
+  `~/.claude/.../memory/feedback_essence_av_sync.md`
+- moraga performance setup (HPM + Interactive QoS + Nice -10):
+  `~/.claude/.../memory/project_moraga_pcore_throttle.md`
+- Forked SDK rationale (no-device app-audio):
+  `~/.claude/.../memory/project_essence_server_audio.md`

--- a/Examples/swift/essence-server/Info.plist
+++ b/Examples/swift/essence-server/Info.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>ai.bithuman.essence-server</string>
+
+    <key>CFBundleName</key>
+    <string>essence-server</string>
+
+    <key>CFBundleExecutable</key>
+    <string>essence-server</string>
+
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+
+    <key>CFBundleVersion</key>
+    <string>1</string>
+
+    <!-- Why we need the microphone, surfaced in the macOS TCC prompt.
+         essence-server doesn't actually capture from the device mic; it
+         publishes audio frames received from the agent-worker brain via
+         LiveKit DataStream. But macOS still requires the entitlement
+         declaration before AVAudioEngine (which underlies LiveKit's
+         LocalAudioTrack) is allowed to initialize at all. -->
+    <key>NSMicrophoneUsageDescription</key>
+    <string>essence-server publishes the AI agent's lip-synced audio response into LiveKit rooms via the system audio engine.</string>
+
+    <!-- Headless agent: no Dock icon, no menubar. -->
+    <key>LSUIElement</key>
+    <true/>
+
+    <!-- Minimum supported macOS. -->
+    <key>LSMinimumSystemVersion</key>
+    <string>14.0</string>
+</dict>
+</plist>

--- a/Examples/swift/essence-server/Package.swift
+++ b/Examples/swift/essence-server/Package.swift
@@ -1,0 +1,57 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+// EssenceServer — a native Swift LiveKit avatar service. Hosts N
+// EssenceRuntime instances behind an HTTP /launch endpoint, joins
+// LiveKit rooms as a participant, and streams lip-synced video + audio
+// back. Drop-in for the Python essence-avatar pool. See ARCHITECTURE.md
+// and README.md.
+//
+// Beyond the bitHumanKit binary, this example pulls in three public
+// SwiftPM deps that are NOT bundled into the framework (they're a server
+// concern, not an SDK concern): the bitHuman LiveKit room SDK fork,
+// JWTKit (LiveKit token minting), and Hummingbird (the HTTP server).
+let package = Package(
+    name: "EssenceServer",
+    platforms: [
+        .macOS("26.0")
+    ],
+    dependencies: [
+        .package(name: "bithuman",
+                 url: "https://github.com/bithuman-product/bithuman-sdk-public.git",
+                 from: "0.8.1"),
+        // bitHuman fork of client-sdk-swift carrying a no-device
+        // app-audio patch (lets headless server avatars publish audio in
+        // manual-render mode without claiming the mic). Drop the fork
+        // once livekit/client-sdk-swift#985 merges + tags.
+        .package(url: "https://github.com/bithuman-product/bithuman-livekit-swift", branch: "main"),
+        .package(url: "https://github.com/vapor/jwt-kit", from: "5.0.0"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird", from: "2.0.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "EssenceServer",
+            dependencies: [
+                .product(name: "bitHumanKit", package: "bithuman"),
+                .product(name: "LiveKit", package: "bithuman-livekit-swift"),
+                .product(name: "JWTKit", package: "jwt-kit"),
+                .product(name: "Hummingbird", package: "hummingbird"),
+            ],
+            path: "Sources/EssenceServer",
+            swiftSettings: [.swiftLanguageMode(.v5)],
+            linkerSettings: [
+                // Embed Info.plist into __TEXT,__info_plist so macOS can
+                // surface NSMicrophoneUsageDescription and TCC grants the
+                // mic access LiveKit's LocalAudioTrack needs. Path is
+                // relative to this package root.
+                .unsafeFlags([
+                    "-Xlinker", "-sectcreate",
+                    "-Xlinker", "__TEXT",
+                    "-Xlinker", "__info_plist",
+                    "-Xlinker", "Info.plist",
+                ]),
+            ]
+        )
+    ]
+)

--- a/Examples/swift/essence-server/README.md
+++ b/Examples/swift/essence-server/README.md
@@ -1,0 +1,44 @@
+# EssenceServer
+
+A native Swift LiveKit avatar service. Hosts N `EssenceRuntime` instances
+behind an HTTP `/launch` endpoint, joins LiveKit rooms as a participant,
+and republishes lip-synced video **and** audio in lockstep. Drop-in
+replacement for the Python `essence-avatar` pool; designed to run as
+launchd-supervised processes on a single Mac.
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the deployment topology,
+process model, and subsystem layout.
+
+## Run
+
+```bash
+cd Examples/swift/essence-server
+swift run -c release EssenceServer
+```
+
+Then `POST /launch` with a room/agent payload to spawn an avatar into a
+LiveKit room. Configuration (port, LiveKit URL/keys, fixture roots) is
+read from the environment — see `Config.swift`.
+
+## Dependencies beyond the SDK
+
+Unlike the app examples, this server pulls in three public SwiftPM
+packages that are **not** bundled into the `bitHumanKit` binary (they're
+a server concern, not an SDK concern):
+
+- `bithuman-livekit-swift` — bitHuman fork of `client-sdk-swift` with a
+  no-device app-audio patch (lets a headless server publish audio in
+  manual-render mode without claiming the mic). Drop the fork once
+  [livekit/client-sdk-swift#985](https://github.com/livekit/client-sdk-swift/pull/985)
+  merges + tags.
+- `jwt-kit` — LiveKit access-token minting.
+- `hummingbird` — the HTTP server hosting `/launch`.
+
+## Requires
+
+- macOS 26+ (Tahoe), Apple Silicon
+- LiveKit Cloud (or self-hosted) credentials
+- One or more `.imx` Essence fixtures
+- Microphone permission (embedded `Info.plist` declares
+  `NSMicrophoneUsageDescription`; TCC grants the mic so LiveKit's
+  `LocalAudioTrack` can initialize for audio republish)

--- a/Examples/swift/essence-server/Sources/EssenceServer/AudioRenderer.swift
+++ b/Examples/swift/essence-server/Sources/EssenceServer/AudioRenderer.swift
@@ -1,0 +1,166 @@
+// SessionAudioRenderer — bridge from a LiveKit `RemoteAudioTrack` into
+// `EssenceRuntime.pushAudio`.
+//
+// The Swift LiveKit SDK delivers audio as `AVAudioPCMBuffer` in whatever
+// format WebRTC negotiated (typically 48 kHz Int16 mono, sometimes
+// float32). EssenceRuntime expects 16 kHz Int16 mono, so we resample
+// every incoming buffer through an `AVAudioConverter` (lazily set up
+// from the first buffer's format).
+//
+// The SDK calls `render(pcmBuffer:)` on its audio thread. We do the
+// resample synchronously there (cheap; AVAudioConverter is C-level)
+// and dispatch the actual `pushAudio` call into a Task so the audio
+// thread is never blocked on the actor.
+//
+// We also track playback timing so EssenceSession can report
+// `lk.playback_finished` back to the brain (livekit-agents avatar
+// protocol). The audio thread updates `lastFrameAt` and accumulates
+// the current speech turn's duration; the session's monitor task
+// reads it to decide when speech ended (silence ≥ idleThreshold).
+//
+// `@unchecked Sendable` — the SDK serializes calls to render(), and
+// our internal mutable state is guarded by `stateLock` for the rare
+// cross-thread reader (the playback monitor).
+
+import AVFoundation
+import LiveKit
+import bitHumanKit
+
+final class SessionAudioRenderer: NSObject, AudioRenderer, @unchecked Sendable {
+
+    static let outFormat: AVAudioFormat = {
+        // 16 kHz mono Int16, interleaved (single channel = trivially "interleaved").
+        AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: 16_000,
+            channels: 1,
+            interleaved: true
+        )!
+    }()
+
+    private let runtime: EssenceRuntime
+    private var converter: AVAudioConverter?
+    private var lastInFormat: AVAudioFormat?
+
+    // Playback-tracking state. Touched from both the SDK audio thread
+    // (in render()) and the session's monitor task (via the public
+    // accessors below). Guarded by stateLock.
+    private let stateLock = NSLock()
+    private var _lastFrameAt: TimeInterval = 0       // monotonic, last non-empty render
+    private var _turnStartedAt: TimeInterval = 0     // when current speech turn began (0 = idle)
+    private var _turnSamples: Int = 0                // samples accumulated this turn (16 kHz)
+    private var _dropUntil: TimeInterval = 0         // drop incoming audio while now < this
+
+    init(runtime: EssenceRuntime) {
+        self.runtime = runtime
+    }
+
+    /// Snapshot of playback state for the monitor task to decide
+    /// whether to fire `playback_finished`.
+    func snapshotForMonitor() -> (active: Bool, lastFrameAt: TimeInterval, position: TimeInterval) {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        let active = _turnStartedAt != 0
+        let position = active ? Double(_turnSamples) / Self.outFormat.sampleRate : 0
+        return (active, _lastFrameAt, position)
+    }
+
+    /// Called by EssenceSession when (a) the brain sent `lk.clear_buffer`
+    /// or (b) we just emitted `playback_finished` ourselves. Resets the
+    /// turn counters so the next inbound audio starts a fresh turn.
+    /// Returns the playback position (seconds) of the turn that just ended.
+    /// `dropForMs` causes incoming audio to be discarded for that window —
+    /// approximates draining the runtime's already-buffered audio after
+    /// an interrupt (the runtime itself has no clear-buffer API).
+    func resetTurn(dropForMs: Int = 0) -> TimeInterval {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        let position = _turnStartedAt != 0
+            ? Double(_turnSamples) / Self.outFormat.sampleRate
+            : 0
+        _turnStartedAt = 0
+        _turnSamples = 0
+        if dropForMs > 0 {
+            _dropUntil = monotonicNow() + Double(dropForMs) / 1000.0
+        }
+        return position
+    }
+
+    func render(pcmBuffer: AVAudioPCMBuffer) {
+        let now = monotonicNow()
+
+        stateLock.lock()
+        if now < _dropUntil {
+            stateLock.unlock()
+            return  // post-interrupt window; drop residual audio
+        }
+        stateLock.unlock()
+
+        let inFmt = pcmBuffer.format
+
+        // Lazily build / rebuild converter when the incoming format changes.
+        if converter == nil || lastInFormat?.isEqual(inFmt) != true {
+            converter = AVAudioConverter(from: inFmt, to: Self.outFormat)
+            lastInFormat = inFmt
+            if converter == nil {
+                FileHandle.standardError.write(Data(
+                    "audio-renderer: AVAudioConverter init failed (in=\(inFmt))\n".utf8))
+                return
+            }
+        }
+        guard let converter else { return }
+
+        let inFrames = pcmBuffer.frameLength
+        guard inFrames > 0 else { return }
+
+        let ratio = Self.outFormat.sampleRate / inFmt.sampleRate
+        let outCapacity = AVAudioFrameCount((Double(inFrames) * ratio).rounded(.up)) + 32
+        guard let outBuf = AVAudioPCMBuffer(pcmFormat: Self.outFormat, frameCapacity: outCapacity)
+        else { return }
+
+        var consumed = false
+        let inputBlock: AVAudioConverterInputBlock = { _, statusOut in
+            if consumed {
+                statusOut.pointee = .noDataNow
+                return nil
+            }
+            consumed = true
+            statusOut.pointee = .haveData
+            return pcmBuffer
+        }
+
+        var nsErr: NSError?
+        let status = converter.convert(to: outBuf, error: &nsErr, withInputFrom: inputBlock)
+        if status == .error || nsErr != nil {
+            FileHandle.standardError.write(Data(
+                "audio-renderer: convert error: \(String(describing: nsErr))\n".utf8))
+            return
+        }
+
+        let outFrames = Int(outBuf.frameLength)
+        guard outFrames > 0,
+              let int16Ptr = outBuf.int16ChannelData?[0]
+        else { return }
+
+        // Update playback-tracking state under the lock.
+        stateLock.lock()
+        if _turnStartedAt == 0 { _turnStartedAt = now }
+        _lastFrameAt = now
+        _turnSamples += outFrames
+        stateLock.unlock()
+
+        let samples = Array(UnsafeBufferPointer(start: int16Ptr, count: outFrames))
+
+        // Hand off to the actor without blocking the audio thread.
+        let runtime = self.runtime
+        Task { await runtime.pushAudio(samples) }
+    }
+}
+
+// Module-private monotonic clock for the renderer + monitor.
+@inline(__always)
+internal func monotonicNow() -> TimeInterval {
+    var ts = timespec()
+    clock_gettime(CLOCK_MONOTONIC, &ts)
+    return Double(ts.tv_sec) + Double(ts.tv_nsec) / 1_000_000_000.0
+}

--- a/Examples/swift/essence-server/Sources/EssenceServer/Config.swift
+++ b/Examples/swift/essence-server/Sources/EssenceServer/Config.swift
@@ -1,0 +1,112 @@
+// Config.swift — central place for the tunables that used to live
+// scattered across EssenceSession.swift, main.swift, plist files, and
+// system commands. Anything that's "what knobs does the server have?"
+// should live here so:
+//
+//   1. There's one greppable file to answer "is X configurable?"
+//   2. Operations changes (raising max-sessions, narrowing the
+//      playback idle threshold, switching codecs for testing) don't
+//      require touching the inner-loop code.
+//   3. Future env-var or YAML overrides land in one parser instead of
+//      sprinkled across the codebase.
+//
+// Usage: read static fields. Call `EssenceServerConfig.applyEnv()` at
+// process start to honor env-var overrides; tests can construct a
+// custom config instance with the public init.
+
+import Foundation
+
+/// Values that affect the avatar's render + publish pipeline. The
+/// defaults here match the production deployment on moraga as of
+/// 2026-05-05 (8 procs × 8 sessions = 64 cap, 720 p @ 25 fps).
+public struct EssenceServerConfig: Sendable {
+    // MARK: - Video
+
+    /// Output frame width in pixels. Avatar runtime composes at this
+    /// width regardless of the model's native frame_wh — the runtime
+    /// internally resizes.
+    public let frameWidth: Int
+
+    /// Output frame height in pixels.
+    public let frameHeight: Int
+
+    /// Target capture rate. The runtime drives this — the LiveKit
+    /// `BufferCaptureOptions.fps` is just an encoder hint.
+    public let fps: Int
+
+    // MARK: - Audio
+
+    /// How long the playback monitor waits after the last non-empty
+    /// audio frame before considering a turn finished and emitting
+    /// `lk.playback_finished`. Should be ≥ ~ runtime audio buffer
+    /// drain time so we don't fire prematurely between TTS chunks.
+    public let playbackIdleThresholdSec: TimeInterval
+
+    // MARK: - Pool / capacity
+
+    /// Per-process session cap. The pool (8 procs) multiplies this
+    /// for the Mac-wide cap. Set via `--max-sessions` on the CLI;
+    /// also written to the plist by `redeploy.sh`. Default 8 here
+    /// matches the launchd template.
+    public let maxSessionsPerProcess: Int
+
+    // MARK: - Init
+
+    public init(
+        frameWidth: Int = 1280,
+        frameHeight: Int = 720,
+        fps: Int = 25,
+        playbackIdleThresholdSec: TimeInterval = 0.8,
+        maxSessionsPerProcess: Int = 8
+    ) {
+        self.frameWidth = frameWidth
+        self.frameHeight = frameHeight
+        self.fps = fps
+        self.playbackIdleThresholdSec = playbackIdleThresholdSec
+        self.maxSessionsPerProcess = maxSessionsPerProcess
+    }
+
+    /// The active config for this process. Writeable so tests can
+    /// install fixtures; production overrides via `applyEnv()` below.
+    /// Reads of this must happen on `EssenceServerConfig.shared`
+    /// (avoids the global-let-vs-actor-isolation pitfall).
+    nonisolated(unsafe) public static var shared = EssenceServerConfig()
+
+    /// Honor environment-variable overrides. Called once at startup
+    /// from `main.swift` before any session is constructed. Variables:
+    ///
+    ///   - `ESSENCE_FRAME_WIDTH`   (Int, default 1280)
+    ///   - `ESSENCE_FRAME_HEIGHT`  (Int, default 720)
+    ///   - `ESSENCE_FPS`           (Int, default 25)
+    ///   - `ESSENCE_IDLE_SEC`      (Double, default 0.8)
+    ///
+    /// Pool size is set per-process via the existing `--max-sessions`
+    /// CLI flag; this method does NOT override that since the launchd
+    /// plist passes it explicitly.
+    public static func applyEnv(maxSessionsPerProcess: Int) {
+        let env = ProcessInfo.processInfo.environment
+
+        func intVar(_ key: String, _ fallback: Int) -> Int {
+            guard let s = env[key], let v = Int(s) else { return fallback }
+            return v
+        }
+        func doubleVar(_ key: String, _ fallback: Double) -> Double {
+            guard let s = env[key], let v = Double(s) else { return fallback }
+            return v
+        }
+
+        let cfg = EssenceServerConfig(
+            frameWidth: intVar("ESSENCE_FRAME_WIDTH", 1280),
+            frameHeight: intVar("ESSENCE_FRAME_HEIGHT", 720),
+            fps: intVar("ESSENCE_FPS", 25),
+            playbackIdleThresholdSec: doubleVar("ESSENCE_IDLE_SEC", 0.8),
+            maxSessionsPerProcess: maxSessionsPerProcess
+        )
+        EssenceServerConfig.shared = cfg
+
+        // Surface the final config so operators see what's actually in
+        // effect, not just what they intended.
+        FileHandle.standardError.write(Data(
+            "essence-server: config frame=\(cfg.frameWidth)x\(cfg.frameHeight) fps=\(cfg.fps) idle=\(cfg.playbackIdleThresholdSec)s max-sessions=\(cfg.maxSessionsPerProcess)\n".utf8))
+    }
+}

--- a/Examples/swift/essence-server/Sources/EssenceServer/EssenceSession.swift
+++ b/Examples/swift/essence-server/Sources/EssenceServer/EssenceSession.swift
@@ -1,0 +1,845 @@
+// EssenceSession — one LiveKit-participant session, one EssenceRuntime.
+//
+// Pipeline (paired A/V from the runtime — matches Python's
+// `BithumanGenerator._stream_impl` which yields VideoFrame +
+// AudioFrame interleaved per output):
+//
+//   brain TTS via byte-stream  ──► SessionAudioRenderer
+//   topic=lk.audio_stream           (resample 24 k Int16 → 16 k Int16)
+//                                       │
+//                                       ▼
+//                                EssenceRuntime.pushAudio
+//                                       │
+//                                       ▼
+//                                runtime.framesWithAudio()
+//                                AsyncStream<EssenceRuntimeFrame>
+//                                       │  (pairs: image + 16 kHz
+//                                       │   mono Int16 chunk that
+//                                       │   produced it)
+//                                       ▼
+//             ┌──────── pair.image ──────────┐
+//             ▼                              ▼
+//   CGImage → CVPixelBuffer            mixer.capture(appAudio: chunk)
+//             │                              │  (16 kHz Int16 wrapped
+//             ▼                              │   as AVAudioPCMBuffer)
+//   BufferCapturer.capture                   ▼
+//             │                       AVAudioEngine mainMixer
+//             ▼                              │
+//   LocalVideoTrack (H264,                   ▼
+//   simulcast=false)                  WebRTC ADM samples
+//             │                              │
+//             ▼                              ▼
+//   local participant publishes        LocalAudioTrack (mic-source,
+//   video to room                      manual rendering)
+//                                            │
+//                                            ▼
+//                                     local participant publishes
+//                                     audio to room
+//
+// **Sync invariant:** every audio chunk we publish on the avatar's
+// audio track is the EXACT 40 ms slice the runtime processed for the
+// paired video frame. This is the only audio path — there is no
+// parallel "feed brain audio directly to mixer.capture" branch
+// (which used to exist and caused multi-second A/V drift since the
+// direct path played at real-time while the runtime path lagged by
+// per-turn cold-start latency). The user's mic track is also NOT
+// fed into the runtime — see `handleSubscribedTrack` — because
+// anything fed to the runtime gets republished, which would loop
+// the user's voice back as the avatar's audio.
+//
+// Lifecycle quirks worth knowing:
+//
+//   - We seed the runtime with 1 s of silence at start so the first
+//     frame (an idle frame) is produced before `publish()` runs. Without
+//     it, `BufferCapturer.dimensionsCompleter` never fires and publish()
+//     stalls for the full `.defaultCaptureStart` (10 s) and throws
+//     `Code=101 Timed out`. (Side effect: that 1 s of silence comes
+//     out of `framesWithAudio()` as actual zero-valued audio chunks
+//     and is published as silence on the audio track. This is fine —
+//     just zero bytes on the wire.)
+//
+//   - `runtime.framesWithAudio()` yields a frame with `audioChunk = nil`
+//     during silent stretches (>100 ms with no real input audio). We
+//     re-emit the cached lastBuffer so the encoder keeps emitting RTP
+//     packets — without that, the SUBSCRIBER PC's DTLS keep-alive
+//     expires and the SDK starts reconnecting. Audio publish is
+//     skipped on these nil-chunk frames, so silence on the wire is
+//     truly silent.
+//
+//   - The SDK fires `didDisconnectWithError(nil)` mid-`cleanUp(isFullReconnect:
+//     true)` whenever it tries to reconnect after a transport hiccup.
+//     We hook `didUpdateConnectionState` instead and only stop on
+//     transitions FROM `.connected`/`.reconnecting` TO `.disconnected`
+//     where the SDK isn't going back to `.reconnecting`.
+//
+//   - LiveKit's `Room` is `@unchecked Sendable`. `BufferCapturer` and
+//     the runtime are likewise actor-friendly. The frame pump is a
+//     detached Task that captures these directly so it doesn't fight
+//     the actor for the lock 25× per second (the actor-bound version
+//     observed 12.5 FPS — half the requested rate — and starved the
+//     SDK signaling task).
+
+import AVFoundation
+import CoreVideo
+import CoreGraphics
+import Foundation
+import LiveKit
+import bitHumanKit
+
+actor EssenceSession {
+
+    enum SessionError: Error, CustomStringConvertible {
+        case capturerCastFailed
+        case pixelBufferAllocFailed(OSStatus)
+        case runtimeBuildFailed(any Error)
+        var description: String {
+            switch self {
+            case .capturerCastFailed:           return "EssenceSession: BufferCapturer cast failed"
+            case .pixelBufferAllocFailed(let s): return "EssenceSession: CVPixelBufferCreate failed (status=\(s))"
+            case .runtimeBuildFailed(let e):     return "EssenceSession: runtime build failed: \(e)"
+            }
+        }
+    }
+
+    // Pull video frame size and rate from `EssenceServerConfig.shared`
+    // (set in `main.swift` from CLI flags + env vars). These shadow
+    // the historical hard-coded constants so most call-sites can
+    // continue using `Self.frameWidth` / `Self.frameHeight` / `Self.fps`
+    // unchanged. `frameIntervalNs` is derived; updates if `fps` changes.
+    private static var frameWidth: Int { EssenceServerConfig.shared.frameWidth }
+    private static var frameHeight: Int { EssenceServerConfig.shared.frameHeight }
+    private static var fps: Int { EssenceServerConfig.shared.fps }
+    fileprivate static var frameIntervalNs: UInt64 {
+        UInt64(1_000_000_000 / EssenceServerConfig.shared.fps)
+    }
+
+    let roomName: String
+    private let fixture: EssenceFixture
+    private let onTerminate: @Sendable (String) async -> Void
+
+    private var runtime: EssenceRuntime?
+    private var room: Room?
+    private var capturer: BufferCapturer?
+    private var pixelBufferPool: CVPixelBufferPool?
+    private var publication: LocalTrackPublication?
+    private var audioTrack: LocalAudioTrack?
+    private var audioPublication: LocalTrackPublication?
+    private var pumpTask: Task<Void, Never>?
+    private var idleTickerTask: Task<Void, Never>?
+    private var audioRenderer: SessionAudioRenderer?
+    private var subscribedAudioTrack: RemoteAudioTrack?
+    private var delegate: SessionRoomDelegate?
+    private var hasBeenConnected = false
+    private var stopped = false
+
+    // livekit-agents avatar-protocol state. The brain (agent-worker)
+    // calls `lk.clear_buffer` on us to interrupt; we reply
+    // `lk.playback_finished` so the brain releases the speech turn.
+    // Brain identity is set on first clear_buffer call and persisted
+    // for subsequent playback_finished sends.
+    private var brainIdentity: Participant.Identity?
+    private var playbackMonitorTask: Task<Void, Never>?
+    private static var playbackIdleThresholdSec: TimeInterval {
+        EssenceServerConfig.shared.playbackIdleThresholdSec
+    }
+
+    init(roomName: String,
+         fixture: EssenceFixture,
+         onTerminate: @escaping @Sendable (String) async -> Void)
+    {
+        self.roomName = roomName
+        self.fixture = fixture
+        self.onTerminate = onTerminate
+    }
+
+    func start(url: String, token: String) async throws {
+        // 1. Build a per-session runtime off the shared fixture.
+        let runtime: EssenceRuntime
+        do {
+            runtime = try Bithuman.createRuntime(fixture: fixture)
+        } catch {
+            throw SessionError.runtimeBuildFailed(error)
+        }
+        self.runtime = runtime
+
+        // 1b. Per-session CVPixelBuffer pool. Reusing IOSurface-backed
+        //     buffers across frames avoids kernel allocs at 25 fps × N
+        //     sessions. Pool size 4 covers the SDK's pipeline depth
+        //     (capture → encode → transmit) with a slack buffer.
+        let poolAttrs: [String: Any] = [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+            kCVPixelBufferWidthKey as String: Self.frameWidth,
+            kCVPixelBufferHeightKey as String: Self.frameHeight,
+            kCVPixelBufferIOSurfacePropertiesKey as String: [:],
+        ]
+        let auxAttrs: [String: Any] = [
+            kCVPixelBufferPoolMinimumBufferCountKey as String: 4,
+        ]
+        var pool: CVPixelBufferPool?
+        CVPixelBufferPoolCreate(nil, auxAttrs as CFDictionary,
+                                poolAttrs as CFDictionary, &pool)
+        self.pixelBufferPool = pool
+
+        // 2. Set up Room + delegate (track-subscribe + connection-state hooks).
+        let delegate = SessionRoomDelegate()
+        let room = Room(delegate: delegate)
+        delegate.onSubscribedTrack = { [weak self] pub in
+            Task { await self?.handleSubscribedTrack(pub) }
+        }
+        delegate.onConnectionState = { [weak self] new, old in
+            Task { await self?.handleConnectionState(new: new, old: old) }
+        }
+        delegate.onParticipantDisconnect = { [weak self] participant, remaining in
+            Task { await self?.handleParticipantDisconnect(participant, remaining: remaining) }
+        }
+        self.delegate = delegate
+        self.room = room
+
+        // 3. Connect signaling (sends JOIN, awaits primary transport).
+        try await room.connect(url: url, token: token)
+
+        // 3b. Register the avatar-side RPC handlers expected by the
+        //     livekit-agents avatar protocol. Without `lk.clear_buffer`
+        //     the brain raises "Method not supported at destination"
+        //     on every interrupt and times out the speech turn.
+        try await room.registerRpcMethod("lk.clear_buffer") { [weak self] data in
+            await self?.handleClearBuffer(callerIdentity: data.callerIdentity)
+            return "ok"
+        }
+
+        // 3b-2. Subscribe to the brain's audio data stream
+        //       (livekit-agents `DataStreamAudioOutput` writes raw PCM
+        //       chunks under topic `lk.audio_stream`). This is how the
+        //       agent's TTS audio reaches us — the brain does NOT
+        //       publish audio as a regular RTC track. We feed each
+        //       chunk into the runtime (for lip-sync) and into
+        //       `AudioManager.shared.mixer.capture(appAudio:)` so the
+        //       audio is also republished on our outgoing track.
+        try await room.registerByteStreamHandler(for: "lk.audio_stream") { [weak self] reader, callerIdentity in
+            await self?.handleAudioByteStream(reader: reader, callerIdentity: callerIdentity)
+        }
+
+        // 3c. Publish an outgoing audio track so users in the room can
+        //     hear what the brain says. The actual PCM is fed into the
+        //     audio engine via `mixer.capture(appAudio:)` in the byte-
+        //     stream handler — the track itself is the wire path.
+        //
+        //     Disable voice-processing I/O before initializing the
+        //     audio track. Voice-processing IO (vp-IO) requires audio-
+        //     session entitlements that ad-hoc-signed CLI binaries
+        //     don't have on macOS, and fails with kAudioUnitErr_
+        //     FailedInitialization (-9000). RemoteIO without voice
+        //     processing has no such requirement — and we don't need
+        //     echo cancellation here anyway since we're not capturing
+        //     a mic, only republishing already-rendered TTS audio.
+        do {
+            try AudioManager.shared.setVoiceProcessingEnabled(false)
+        } catch {
+            FileHandle.standardError.write(Data(
+                "essence-session: setVoiceProcessingEnabled(false) warned: \(error)\n".utf8))
+        }
+        // Use setMicrophone(enabled: true) rather than building a custom
+        // LocalAudioTrack: in manual rendering mode this is what the SDK
+        // expects — it starts the WebRTC ADM in the no-device branch and
+        // brings the AVAudioEngine up so `mixer.capture(appAudio:)` can
+        // pump brain audio into mainMixer → published track. Mirrors the
+        // SDK's own `testManualRenderingModePublishAudio` test pattern.
+        // Disable echo cancellation / AGC / noise suppression — we are
+        // not capturing a real mic, just republishing rendered TTS.
+        let captureOpts = AudioCaptureOptions(
+            echoCancellation: false,
+            autoGainControl: false,
+            noiseSuppression: false,
+            highpassFilter: false,
+            typingNoiseDetection: false
+        )
+        do {
+            let pub = try await room.localParticipant.setMicrophone(
+                enabled: true,
+                captureOptions: captureOpts
+            )
+            self.audioTrack = pub?.track as? LocalAudioTrack
+            self.audioPublication = pub
+            FileHandle.standardError.write(Data(
+                "essence-session: mic-source audio track published (manual rendering — no device claim)\n".utf8))
+        } catch {
+            FileHandle.standardError.write(Data(
+                "essence-session: setMicrophone(enabled:true) failed (\(error)) — proceeding without audio republish\n".utf8))
+            self.audioTrack = nil
+            self.audioPublication = nil
+        }
+
+        // 3c. Kick off the playback monitor — fires
+        //     `lk.playback_finished` to the brain when audio rendering
+        //     stops for >`playbackIdleThresholdSec`. This is what
+        //     releases the brain from waiting for playback to complete.
+        playbackMonitorTask = startPlaybackMonitor()
+
+        // 4. Build the publishing pipeline.
+        let opts = BufferCaptureOptions(
+            dimensions: Dimensions(width: Int32(Self.frameWidth),
+                                   height: Int32(Self.frameHeight)),
+            fps: Self.fps
+        )
+        let track = LocalVideoTrack.createBufferTrack(
+            name: "avatar_video",
+            source: .camera,
+            options: opts
+        )
+        guard let cap = track.capturer as? BufferCapturer else {
+            throw SessionError.capturerCastFailed
+        }
+        self.capturer = cap
+
+        // 5. Audio renderer — gets attached once we see a remote audio track.
+        self.audioRenderer = SessionAudioRenderer(runtime: runtime)
+
+        // 6. Pump runtime.frames() → CVPixelBuffer → capturer. Detached so
+        //    it doesn't fight the actor for the lock 25×/s.
+        pumpTask = Self.spawnFramePump(
+            runtime: runtime,
+            capturer: cap,
+            width: Self.frameWidth,
+            height: Self.frameHeight,
+            pool: pool,
+            roomName: self.roomName
+        )
+
+        // 7. Bootstrap: push 1 s of silence so the runtime emits a real
+        //    first frame before `publish()` awaits the dimensionsCompleter.
+        let silence = [Int16](repeating: 0, count: 16_000)
+        await runtime.pushAudio(silence)
+
+        // 8. Publish.
+        let pub = try await room.localParticipant.publish(
+            videoTrack: track,
+            options: VideoPublishOptions(
+                name: "avatar_video",
+                simulcast: false,
+                preferredCodec: .h264
+            )
+        )
+        self.publication = pub
+
+        // 9. If there's already a subscribed audio track, attach now
+        //    (handles the rare case where the agent published before us).
+        for participant in room.remoteParticipants.values {
+            for trackPub in participant.audioTracks {
+                if let p = trackPub as? RemoteTrackPublication {
+                    await handleSubscribedTrack(p)
+                }
+            }
+        }
+    }
+
+    // MARK: - Frame pump
+
+    /// Drains `runtime.frames()` and forwards each yielded CGImage to
+    /// the LiveKit `BufferCapturer`. Detached so it doesn't fight the
+    /// actor lock 25× per second.
+    ///
+    /// The runtime emits frames in a bursty pattern (25 in a fast
+    /// burst as the audio buffer drains, then quieter while it
+    /// rebuffers — including a synthetic silent-chunk path that loops
+    /// the idle video at 25 FPS). This produces ~14 FPS at the encoder
+    /// after WebRTC's adaptive throttling, with elevated jitter. A
+    /// fixed-cadence DispatchSourceTimer was tried (decoupling consume
+    /// from capture); it produced lower jitter but higher
+    /// frame loss because the timer races the consumer at startup
+    /// (slot empty for the first few ticks → no key frame; the
+    /// encoder's session establishment fails). Reverted to the
+    /// straight `for await` until we have a real audio source driving
+    /// the runtime — then the cadence becomes steady on its own.
+    private static func spawnFramePump(
+        runtime: EssenceRuntime,
+        capturer: BufferCapturer,
+        width: Int,
+        height: Int,
+        pool: CVPixelBufferPool?,
+        roomName: String
+    ) -> Task<Void, Never> {
+        // 16 kHz mono int16 — the runtime's internal audio format,
+        // also the format the runtime hands back per-frame audio
+        // chunks in. Built once and reused for every chunk's
+        // AVAudioPCMBuffer.
+        let runtimeAudioFormat: AVAudioFormat? = AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: 16_000,
+            channels: 1,
+            interleaved: true
+        )
+        return Task.detached(priority: .userInitiated) {
+            // Use the paired audio+video stream: each yielded element
+            // is the runtime's image AND the 40 ms audio slice that
+            // produced it. Publishing both together gives perfect
+            // lipsync — same wall-clock instant for the video frame
+            // and its corresponding audio. Mirrors Python's
+            // `BithumanGenerator._stream_impl` which yields paired
+            // VideoFrame + AudioFrame.
+            let stream = await runtime.framesWithAudio()
+            var lastBuffer: CVPixelBuffer?
+            var realFrames = 0
+            var reemittedFrames = 0
+            var windowStart = monotonicNow()
+            for await pair in stream {
+                if Task.isCancelled { break }
+                let ts = VideoCapturer.createTimeStampNs()
+                if let cgImage = pair.image {
+                    if let pb = makePixelBuffer(from: cgImage, width: width, height: height, pool: pool) {
+                        lastBuffer = pb
+                        capturer.capture(pb, timeStampNs: ts)
+                        realFrames += 1
+                        EssenceMetrics.shared.incrFramesPublished()
+                    }
+                } else if let pb = lastBuffer {
+                    capturer.capture(pb, timeStampNs: ts)
+                    reemittedFrames += 1
+                }
+                // Publish audio for THIS frame at the same wall-clock
+                // instant the video was captured. `audioChunk == nil`
+                // means runtime synthesised a silent tick — skip
+                // publishing rather than wasting bytes on silence.
+                if let chunk = pair.audioChunk, let fmt = runtimeAudioFormat {
+                    publishRuntimeAudioChunk(chunk, format: fmt)
+                    EssenceMetrics.shared.incrAudioChunksPublished()
+                }
+                let elapsed = monotonicNow() - windowStart
+                if elapsed >= 1.0 {
+                    let total = realFrames + reemittedFrames
+                    let realFps = Double(realFrames) / elapsed
+                    let totalFps = Double(total) / elapsed
+                    FileHandle.standardError.write(Data(
+                        "essence-session: pump fps room=\(roomName) real=\(String(format: "%.1f", realFps)) total=\(String(format: "%.1f", totalFps))\n".utf8))
+                    realFrames = 0
+                    reemittedFrames = 0
+                    windowStart = monotonicNow()
+                }
+            }
+        }
+    }
+
+    /// Wrap a runtime audio chunk (16 kHz mono int16, 640 samples =
+    /// 40 ms) into an `AVAudioPCMBuffer` and feed it to the SDK's
+    /// app-audio path. Called from the framepump per emitted frame.
+    private static func publishRuntimeAudioChunk(_ chunk: [Int16], format: AVAudioFormat) {
+        guard !chunk.isEmpty else { return }
+        guard let buf = AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(chunk.count)
+        ) else { return }
+        buf.frameLength = AVAudioFrameCount(chunk.count)
+        if let dst = buf.int16ChannelData?[0] {
+            chunk.withUnsafeBufferPointer { srcPtr in
+                if let srcBase = srcPtr.baseAddress {
+                    memcpy(dst, srcBase, chunk.count * MemoryLayout<Int16>.size)
+                }
+            }
+        }
+        AudioManager.shared.mixer.capture(appAudio: buf)
+    }
+
+    // MARK: - Delegate handlers
+
+    private func handleSubscribedTrack(_ pub: RemoteTrackPublication) async {
+        guard subscribedAudioTrack == nil,
+              let audioTrack = pub.track as? RemoteAudioTrack
+        else { return }
+
+        // We track the subscribed audio track only as a fallback path
+        // for `inferAudioPublisher` (used when brainIdentity isn't
+        // known yet). We do NOT attach the SessionAudioRenderer here
+        // — the renderer feeds the runtime, and the only audio that
+        // should drive the runtime is the brain's TTS arriving via
+        // the `lk.audio_stream` byte-stream. Attaching the renderer
+        // to the user's mic would loop the user's voice into the
+        // runtime → which the framepump would then republish on the
+        // avatar's audio track → user hears their own voice played
+        // back by the avatar.
+        FileHandle.standardError.write(Data(
+            "essence-session: tracking remote audio track \(pub.sid.stringValue) (NOT fed to runtime — runtime is driven by brain byte-stream only)\n".utf8))
+        subscribedAudioTrack = audioTrack
+        _ = audioRenderer
+    }
+
+    /// Handle the brain's audio byte stream (livekit-agents
+    /// `DataStreamAudioOutput`). Each chunk is raw Int16 PCM at
+    /// `sample_rate` Hz / `num_channels` channels (set as stream
+    /// attributes by the sender). For each chunk we:
+    ///   1. Convert to AVAudioPCMBuffer in the sender's format.
+    ///   2. Feed the runtime via SessionAudioRenderer.render() — drives
+    ///      lip-sync (resampled to 16 kHz Int16 mono inside).
+    ///   3. Push to AudioManager.shared.mixer.capture(appAudio:) so the
+    ///      same audio is republished on our outgoing audio track for
+    ///      users to hear.
+    nonisolated private func handleAudioByteStream(
+        reader: ByteStreamReader,
+        callerIdentity: Participant.Identity
+    ) async {
+        let info = reader.info
+        let sampleRate = Double(info.attributes["sample_rate"] ?? "") ?? 48_000
+        let numChannels = AVAudioChannelCount(info.attributes["num_channels"] ?? "1") ?? 1
+        guard let inFmt = AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: sampleRate,
+            channels: numChannels,
+            interleaved: true
+        ) else { return }
+
+        FileHandle.standardError.write(Data(
+            "essence-session: byte-stream OPEN  topic=\(info.topic) caller=\(callerIdentity) sr=\(Int(sampleRate)) ch=\(numChannels)\n".utf8))
+
+        // Capture the brain's identity from the very first audio
+        // byte-stream. Without this, the avatar only learns the brain
+        // identity when the brain sends `lk.clear_buffer` (an
+        // interruption); a non-interrupted greeting playback means
+        // we never get clear_buffer, never know the brain, and never
+        // fire `lk.playback_finished` — the brain then hangs in its
+        // "speaking" state forever and the UI sticks at "connecting".
+        // Brain uses `DataStreamAudioOutput`, so it never publishes a
+        // mic track; the byte-stream caller IS the brain.
+        await self.recordBrainIdentity(callerIdentity)
+
+        // Pull the renderer reference once (actor-isolated read). The
+        // renderer itself is @unchecked Sendable; we call into it from
+        // the byte-stream's executor.
+        let renderer = await self.audioRenderer
+
+        var totalBytes = 0
+        var totalChunks = 0
+        var lastLogAt = monotonicNow()
+
+        do {
+            for try await chunk in reader {
+                guard !chunk.isEmpty else { continue }
+                let bytesPerFrame = 2 * Int(numChannels)  // Int16 mono/stereo
+                let frameCount = chunk.count / bytesPerFrame
+                guard frameCount > 0 else { continue }
+
+                guard let buf = AVAudioPCMBuffer(
+                    pcmFormat: inFmt,
+                    frameCapacity: AVAudioFrameCount(frameCount)
+                ) else { continue }
+                buf.frameLength = AVAudioFrameCount(frameCount)
+
+                if let dst = buf.int16ChannelData?[0] {
+                    chunk.withUnsafeBytes { rawPtr in
+                        if let srcBase = rawPtr.baseAddress {
+                            memcpy(dst, srcBase, chunk.count)
+                        }
+                    }
+                }
+
+                // Feed runtime; the runtime's audio→video pump emits
+                // paired (image, 40 ms audio chunk) tuples that the
+                // framepump publishes together. We do NOT call
+                // `mixer.capture(appAudio:)` here — the framepump
+                // does it per emitted frame using the runtime's
+                // OUTPUT audio (the same 40 ms slice that produced
+                // the image). That's what locks A/V sync regardless
+                // of brain bursting or runtime startup latency.
+                renderer?.render(pcmBuffer: buf)
+
+                totalBytes += chunk.count
+                totalChunks += 1
+                EssenceMetrics.shared.incrByteStreamChunks()
+                let now = monotonicNow()
+                if now - lastLogAt > 1.0 {
+                    FileHandle.standardError.write(Data(
+                        "essence-session: byte-stream rcv  chunks=\(totalChunks) bytes=\(totalBytes) — last frameCount=\(frameCount)\n".utf8))
+                    lastLogAt = now
+                }
+            }
+        } catch {
+            FileHandle.standardError.write(Data(
+                "essence-session: audio byte-stream error: \(error) (after \(totalChunks) chunks, \(totalBytes) bytes)\n".utf8))
+        }
+        FileHandle.standardError.write(Data(
+            "essence-session: byte-stream CLOSE  totalChunks=\(totalChunks) totalBytes=\(totalBytes)\n".utf8))
+    }
+
+    // MARK: - livekit-agents avatar-protocol RPC
+
+    /// Brain interrupted us — drop in-flight queued audio and report
+    /// `playback_finished(interrupted: true)` so the brain releases the
+    /// turn. EssenceRuntime has no clear-buffer API, so we approximate
+    /// by dropping new audio for a short window (the runtime's already-
+    /// buffered audio plays out — typically <300 ms).
+    private func handleClearBuffer(callerIdentity: Participant.Identity) async {
+        EssenceMetrics.shared.incrClearBuffer()
+        if brainIdentity == nil {
+            brainIdentity = callerIdentity
+        }
+        let position = audioRenderer?.resetTurn(dropForMs: 250) ?? 0
+        await firePlaybackFinished(interrupted: true, position: position)
+    }
+
+    /// Set `brainIdentity` if it isn't already known. Called from the
+    /// audio byte-stream handler with the caller identity, since the
+    /// brain (livekit-agents `DataStreamAudioOutput`) never publishes
+    /// a mic track and `lk.clear_buffer` only fires on interruption.
+    private func recordBrainIdentity(_ identity: Participant.Identity) {
+        if brainIdentity == nil {
+            brainIdentity = identity
+        }
+    }
+
+    private func firePlaybackFinished(interrupted: Bool, position: TimeInterval) async {
+        guard let room, let brain = brainIdentity else { return }
+        // Schema must match livekit.agents.voice.io.PlaybackFinishedEvent.
+        let payload = """
+        {"playback_position": \(position), "interrupted": \(interrupted ? "true" : "false")}
+        """
+        do {
+            _ = try await room.localParticipant.performRpc(
+                destinationIdentity: brain,
+                method: "lk.playback_finished",
+                payload: payload
+            )
+            EssenceMetrics.shared.incrPlaybackFinished()
+        } catch {
+            FileHandle.standardError.write(Data(
+                "essence-session: playback_finished rpc failed: \(error)\n".utf8))
+        }
+    }
+
+    /// Polls the audio renderer 4×/sec; when a turn was active and the
+    /// last audio frame was >`playbackIdleThresholdSec` ago, treat the
+    /// turn as ended and report `playback_finished(interrupted: false)`.
+    private func startPlaybackMonitor() -> Task<Void, Never> {
+        Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 250_000_000)  // 250 ms
+                await self?.tickPlaybackMonitor()
+            }
+        }
+    }
+
+    private func tickPlaybackMonitor() async {
+        guard let renderer = audioRenderer else { return }
+        let snap = renderer.snapshotForMonitor()
+        guard snap.active else { return }
+        let elapsed = monotonicNow() - snap.lastFrameAt
+        guard elapsed >= Self.playbackIdleThresholdSec else { return }
+        // We need a brain identity to send to. If none yet (no
+        // clear_buffer ever fired), fall back to the audio-track
+        // publisher.
+        if brainIdentity == nil,
+           let track = subscribedAudioTrack,
+           let participant = inferAudioPublisher(of: track)
+        {
+            brainIdentity = participant.identity
+        }
+        let position = renderer.resetTurn()
+        guard brainIdentity != nil else { return }  // can't notify — drop
+        await firePlaybackFinished(interrupted: false, position: position)
+    }
+
+    private func inferAudioPublisher(of track: RemoteAudioTrack) -> RemoteParticipant? {
+        guard let room else { return nil }
+        for p in room.remoteParticipants.values {
+            for pub in p.audioTracks {
+                if (pub as? RemoteTrackPublication)?.track?.sid == track.sid {
+                    return p
+                }
+            }
+        }
+        return nil
+    }
+
+    private func handleConnectionState(new: ConnectionState, old: ConnectionState) async {
+        FileHandle.standardError.write(Data(
+            "essence-session: connection \(old) → \(new)\n".utf8))
+
+        if case .connected = new {
+            hasBeenConnected = true
+            return
+        }
+
+        // The SDK fires `.connected → .reconnecting → .disconnected` mid
+        // `cleanUp(isFullReconnect:)` and then transitions back to
+        // `.connecting → .connected`. Reacting to `.disconnected`
+        // synchronously would interrupt that recovery. Instead, schedule
+        // a delayed recheck — if the SDK has recovered by then, the
+        // state will be `.connected` (or `.reconnecting`/`.connecting`)
+        // and we leave it alone. If it's still `.disconnected`, the
+        // recovery genuinely failed and we should release the slot.
+        if case .disconnected = new, hasBeenConnected, !stopped {
+            Task { [weak self] in
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                await self?.confirmTerminalDisconnect()
+            }
+        }
+    }
+
+    /// Brain or user (or both) left the room. When EVERY remote
+    /// participant has gone, the avatar is alone — there is nobody
+    /// left to receive its frames. Self-stop instead of lingering as
+    /// a zombie until process restart, which used to be the only way
+    /// to free the slot. (Slot leakage was the workaround we did
+    /// dozens of times during stress testing — `launchctl bootout`+
+    /// `bootstrap` to reset every process.)
+    ///
+    /// `remaining` is the count AFTER the just-disconnected
+    /// participant left, so 0 means the room is empty of remotes.
+    private func handleParticipantDisconnect(_ participant: RemoteParticipant, remaining: Int) async {
+        FileHandle.standardError.write(Data(
+            "essence-session: participant disconnected: \(participant.identity?.stringValue ?? "?") (sdk-reported remaining=\(remaining))\n".utf8))
+        guard !stopped else { return }
+        // Don't gate on `remaining` here — it sometimes includes the
+        // just-disconnected participant or counts agent-dispatcher
+        // identities the SDK lists as remote. Always schedule a
+        // grace-period recheck and let `confirmEmptyRoom` make the
+        // decision against the room's settled state.
+        Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 1_500_000_000)  // 1.5 s
+            await self?.confirmEmptyRoom()
+        }
+    }
+
+    private func confirmEmptyRoom() async {
+        guard !stopped, let room else { return }
+        // Filter out the avatar participants the SDK sometimes
+        // exposes via `remoteParticipants` (livekit-cloud agent
+        // dispatcher identities, etc.). What we care about is real
+        // peers that are subscribing to our audio/video — typically
+        // the brain (agent-worker) and the user (browser). If both
+        // are gone, we have no consumers.
+        let realPeers = room.remoteParticipants.values.filter { p in
+            // Skip the LiveKit agent-dispatcher pseudo-participant
+            // (identities like "agent-AJ_xxxxx"). They're metadata,
+            // not consumers.
+            let id = p.identity?.stringValue ?? ""
+            return !id.hasPrefix("agent-AJ_")
+        }
+        guard realPeers.isEmpty else {
+            FileHandle.standardError.write(Data(
+                "essence-session: room still has \(realPeers.count) real peer(s) — not stopping\n".utf8))
+            return
+        }
+        FileHandle.standardError.write(Data(
+            "essence-session: room empty (no real peers) after grace; self-stopping\n".utf8))
+        EssenceMetrics.shared.incrRoomEmptyTermination()
+        await stop(reason: "room-empty")
+    }
+
+    private func confirmTerminalDisconnect() async {
+        guard !stopped, let room else { return }
+        let state = room.connectionState
+        if state == .disconnected {
+            await stop(reason: "connection-state-terminal")
+        } else {
+            FileHandle.standardError.write(Data(
+                "essence-session: skipping terminal stop, state=\(state)\n".utf8))
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    func stop(reason: String = "explicit") async {
+        guard !stopped else { return }
+        stopped = true
+        FileHandle.standardError.write(Data(
+            "essence-session: stop room=\(roomName) reason=\(reason)\n".utf8))
+
+        pumpTask?.cancel()
+        idleTickerTask?.cancel()
+        playbackMonitorTask?.cancel()
+        pumpTask = nil
+        idleTickerTask = nil
+        playbackMonitorTask = nil
+
+        // Note: SessionAudioRenderer is no longer attached to remote
+        // tracks (see handleSubscribedTrack), so there is no
+        // `track.remove(audioRenderer:)` to do here. Just drop the
+        // refs and let ARC clean up.
+        subscribedAudioTrack = nil
+        audioRenderer = nil
+        audioTrack = nil
+        audioPublication = nil
+
+        if let runtime { await runtime.stop() }
+        runtime = nil
+
+        await room?.disconnect()
+        room = nil
+        capturer = nil
+        publication = nil
+        delegate = nil
+
+        await onTerminate(roomName)
+    }
+}
+
+// MARK: - CGImage → CVPixelBuffer (BGRA)
+
+/// Draws `image` into a 32BGRA pixel buffer of the given size,
+/// letterboxing / scaling via Core Graphics. If a `pool` is provided,
+/// recycles a buffer from it (preferred — avoids IOSurface kernel
+/// allocs per frame). Otherwise allocates one. Returns nil on alloc
+/// failure (rare).
+func makePixelBuffer(from image: CGImage, width: Int, height: Int,
+                     pool: CVPixelBufferPool? = nil) -> CVPixelBuffer? {
+    var pb: CVPixelBuffer?
+    let status: CVReturn
+    if let pool {
+        status = CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &pb)
+    } else {
+        let attrs: [String: Any] = [
+            kCVPixelBufferIOSurfacePropertiesKey as String: [:],
+        ]
+        status = CVPixelBufferCreate(
+            kCFAllocatorDefault, width, height,
+            kCVPixelFormatType_32BGRA,
+            attrs as CFDictionary,
+            &pb
+        )
+    }
+    guard status == kCVReturnSuccess, let buf = pb else { return nil }
+
+    CVPixelBufferLockBaseAddress(buf, [])
+    defer { CVPixelBufferUnlockBaseAddress(buf, []) }
+
+    guard let ctx = CGContext(
+        data: CVPixelBufferGetBaseAddress(buf),
+        width: width, height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: CVPixelBufferGetBytesPerRow(buf),
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
+                  | CGBitmapInfo.byteOrder32Little.rawValue
+    ) else { return nil }
+
+    ctx.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+    return buf
+}
+
+// MARK: - RoomDelegate adapter
+
+/// LiveKit's RoomDelegate is `@objc` so it must be an NSObject. We
+/// bounce events into closures that the actor can wire to its own
+/// methods.
+final class SessionRoomDelegate: NSObject, RoomDelegate, @unchecked Sendable {
+    var onSubscribedTrack: (@Sendable (RemoteTrackPublication) -> Void)?
+    var onConnectionState: (@Sendable (ConnectionState, ConnectionState) -> Void)?
+    var onParticipantDisconnect: (@Sendable (RemoteParticipant, Int) -> Void)?
+
+    func room(_ room: Room,
+              participant: RemoteParticipant,
+              didSubscribeTrack publication: RemoteTrackPublication)
+    {
+        onSubscribedTrack?(publication)
+    }
+
+    func room(_ room: Room,
+              didUpdateConnectionState connectionState: ConnectionState,
+              from oldConnectionState: ConnectionState)
+    {
+        onConnectionState?(connectionState, oldConnectionState)
+    }
+
+    func room(_ room: Room, participantDidDisconnect participant: RemoteParticipant) {
+        // Pass the *remaining* remote count so the actor handler can
+        // decide if the room is empty without re-reading state.
+        onParticipantDisconnect?(participant, room.remoteParticipants.count)
+    }
+}

--- a/Examples/swift/essence-server/Sources/EssenceServer/FixtureCache.swift
+++ b/Examples/swift/essence-server/Sources/EssenceServer/FixtureCache.swift
@@ -1,0 +1,60 @@
+// FixtureCache — one `EssenceFixture` per avatarID, shared across
+// every `EssenceRuntime` we spin up for that avatar.
+//
+// Why a cache: `Bithuman.loadEssenceFixture(modelPath:)` is the
+// expensive call (~1–2 s, ~200 MB resident). Once loaded, building a
+// runtime off it (`Bithuman.createRuntime(fixture:)`) is ~50–100 ms
+// and adds only ~30–40 MB per instance. Hosting N concurrent avatars
+// of the same model costs `200 + 30N` MB instead of `230N`.
+//
+// EssenceFixture is reference-counted — once every runtime built from
+// it has been released, the fixture deallocates. We hold a strong
+// reference here for the lifetime of the process, deliberately: the
+// expectation is that `agent-root` has a small set of hot avatars
+// that benefit from being kept warm. If avatar churn becomes a real
+// concern, swap this for an LRU.
+
+import Foundation
+import bitHumanKit
+
+actor FixtureCache {
+    enum FixtureError: Error, CustomStringConvertible {
+        case loadFailed(avatarID: String, path: String, underlying: Error)
+        var description: String {
+            switch self {
+            case .loadFailed(let id, let path, let err):
+                return "fixture load failed (\(id) at \(path)): \(err)"
+            }
+        }
+    }
+
+    private var fixtures: [String: EssenceFixture] = [:]
+    private var inflight: [String: Task<EssenceFixture, Error>] = [:]
+
+    /// Return a (cached) fixture for `avatarID`, loading from disk on
+    /// first request. Concurrent callers for the same avatarID share a
+    /// single load Task.
+    func get(avatarID: String, imxPath: URL) async throws -> EssenceFixture {
+        if let hit = fixtures[avatarID] { return hit }
+        if let task = inflight[avatarID] { return try await task.value }
+
+        let task = Task<EssenceFixture, Error> {
+            do {
+                return try Bithuman.loadEssenceFixture(modelPath: imxPath)
+            } catch {
+                throw FixtureError.loadFailed(avatarID: avatarID, path: imxPath.path, underlying: error)
+            }
+        }
+        inflight[avatarID] = task
+        defer { inflight[avatarID] = nil }
+
+        let fixture = try await task.value
+        fixtures[avatarID] = fixture
+        return fixture
+    }
+
+    /// Number of avatars currently warm — surfaced via `/status` if
+    /// useful for diagnostics.
+    func warmCount() -> Int { fixtures.count }
+    func warmIDs()   -> [String] { Array(fixtures.keys) }
+}

--- a/Examples/swift/essence-server/Sources/EssenceServer/Metrics.swift
+++ b/Examples/swift/essence-server/Sources/EssenceServer/Metrics.swift
@@ -1,0 +1,100 @@
+// Metrics.swift — process-wide counters and a /metrics endpoint that
+// emits Prometheus-compatible text. Lets operators scrape:
+//
+//   curl http://moraga:8089/metrics
+//
+// and graph "are sessions completing? are frames flowing? is the
+// runtime keeping up?" without grepping logs.
+//
+// Counters are atomic (lock-free) so they're safe to bump from any
+// thread (`Task.detached` framepump, byte-stream readers, the actor
+// itself). Output is bog-standard Prometheus text v0.0.4 — works
+// with Grafana, Datadog, and `promtool check metrics`.
+
+import Foundation
+
+/// Process-wide counter store. Each metric is a `os.Atomic<UInt64>`
+/// (since macOS 26 ships with std atomics) — wrapped to give the
+/// rest of the codebase a stable add/get API even if the underlying
+/// primitive changes (e.g. distinguishing per-session vs aggregate).
+public final class EssenceMetrics: @unchecked Sendable {
+
+    /// Counters and gauges exposed at /metrics. Comment lines explain
+    /// what each is so the Prometheus help text is meaningful.
+    public struct Snapshot {
+        public var sessionsActive: UInt64 = 0
+        public var sessionsTotalStarted: UInt64 = 0
+        public var sessionsTotalTerminated: UInt64 = 0
+        public var sessionsLaunchFailed: UInt64 = 0
+        public var framesPublishedTotal: UInt64 = 0
+        public var audioChunksPublishedTotal: UInt64 = 0
+        public var byteStreamChunksReceivedTotal: UInt64 = 0
+        public var rpcPlaybackFinishedTotal: UInt64 = 0
+        public var rpcClearBufferTotal: UInt64 = 0
+        public var roomEmptyTerminationsTotal: UInt64 = 0
+    }
+
+    private let lock = NSLock()
+    private var snap = Snapshot()
+    private let processStart = Date()
+
+    public static let shared = EssenceMetrics()
+
+    public func setActiveSessions(_ n: UInt64) {
+        lock.lock(); defer { lock.unlock() }
+        snap.sessionsActive = n
+    }
+    public func incrSessionsStarted()           { incr(\.sessionsTotalStarted) }
+    public func incrSessionsTerminated()        { incr(\.sessionsTotalTerminated) }
+    public func incrLaunchFailed()              { incr(\.sessionsLaunchFailed) }
+    public func incrFramesPublished()           { incr(\.framesPublishedTotal) }
+    public func incrAudioChunksPublished()      { incr(\.audioChunksPublishedTotal) }
+    public func incrByteStreamChunks()          { incr(\.byteStreamChunksReceivedTotal) }
+    public func incrPlaybackFinished()          { incr(\.rpcPlaybackFinishedTotal) }
+    public func incrClearBuffer()               { incr(\.rpcClearBufferTotal) }
+    public func incrRoomEmptyTermination()      { incr(\.roomEmptyTerminationsTotal) }
+
+    private func incr(_ kp: WritableKeyPath<Snapshot, UInt64>) {
+        lock.lock(); defer { lock.unlock() }
+        snap[keyPath: kp] &+= 1
+    }
+
+    /// Snapshot the whole struct under one lock. Cheaper than
+    /// individual atomic reads at scrape time.
+    public func snapshot() -> Snapshot {
+        lock.lock(); defer { lock.unlock() }
+        return snap
+    }
+
+    /// Render the snapshot as Prometheus text v0.0.4. Each metric
+    /// gets a `# HELP` and `# TYPE` line; values follow on a single
+    /// line each. Process uptime is included so dashboards can spot
+    /// recent restarts.
+    public func renderPrometheus() -> String {
+        let s = snapshot()
+        let uptime = Date().timeIntervalSince(processStart)
+        var out = ""
+        func emit(_ name: String, _ help: String, _ type: String, _ value: UInt64) {
+            out += "# HELP essence_\(name) \(help)\n"
+            out += "# TYPE essence_\(name) \(type)\n"
+            out += "essence_\(name) \(value)\n"
+        }
+        func emitFloat(_ name: String, _ help: String, _ type: String, _ value: Double) {
+            out += "# HELP essence_\(name) \(help)\n"
+            out += "# TYPE essence_\(name) \(type)\n"
+            out += "essence_\(name) \(value)\n"
+        }
+        emit("sessions_active", "Sessions currently running on this process", "gauge", s.sessionsActive)
+        emit("sessions_started_total", "Sessions that successfully started since process boot", "counter", s.sessionsTotalStarted)
+        emit("sessions_terminated_total", "Sessions that ended for any reason", "counter", s.sessionsTotalTerminated)
+        emit("sessions_launch_failed_total", "/launch requests that failed before reserving a slot", "counter", s.sessionsLaunchFailed)
+        emit("frames_published_total", "Real (non-reemitted) video frames published to LiveKit", "counter", s.framesPublishedTotal)
+        emit("audio_chunks_published_total", "40 ms audio chunks published to LiveKit (paired with video frames)", "counter", s.audioChunksPublishedTotal)
+        emit("byte_stream_chunks_received_total", "Audio chunks received from the brain via lk.audio_stream", "counter", s.byteStreamChunksReceivedTotal)
+        emit("rpc_playback_finished_total", "lk.playback_finished RPCs sent to the brain", "counter", s.rpcPlaybackFinishedTotal)
+        emit("rpc_clear_buffer_total", "lk.clear_buffer RPCs received from the brain", "counter", s.rpcClearBufferTotal)
+        emit("room_empty_terminations_total", "Sessions self-stopped because the room emptied of real peers", "counter", s.roomEmptyTerminationsTotal)
+        emitFloat("process_uptime_seconds", "Seconds since this essence-server process started", "gauge", uptime)
+        return out
+    }
+}

--- a/Examples/swift/essence-server/Sources/EssenceServer/ModelStore.swift
+++ b/Examples/swift/essence-server/Sources/EssenceServer/ModelStore.swift
@@ -1,0 +1,84 @@
+// ModelStore — lazy resolver for `{agentRoot}/{avatarID}/*.imx`.
+//
+// Mirrors the Python dispatcher's `_ensure_model_available`:
+//   1. Glob the avatar's directory; return any matching .imx.
+//   2. If absent and `modelURL` is provided, download to disk under a
+//      `.downloading` lock then atomic-rename into place.
+//   3. If absent and no URL, throw .notFound (the dispatcher returns 400).
+//
+// One actor for the whole process — serializes downloads of the same
+// avatarID, doesn't block lookups for other avatars (all I/O happens
+// inside the actor; concurrent readers of distinct avatars share zero
+// state once the path is resolved).
+
+import Foundation
+
+actor ModelStore {
+    enum ModelError: Error, CustomStringConvertible {
+        case notFound(avatarID: String, root: String)
+        case downloadFailed(URL, underlying: Error)
+        case writeFailed(String, underlying: Error)
+
+        var description: String {
+            switch self {
+            case .notFound(let id, let root):
+                return "model not found: no .imx under \(root)/\(id)/ and no model_url provided"
+            case .downloadFailed(let url, let err):
+                return "model download failed (\(url.absoluteString)): \(err)"
+            case .writeFailed(let path, let err):
+                return "model write failed (\(path)): \(err)"
+            }
+        }
+    }
+
+    let agentRoot: URL
+    private var inflight: [String: Task<URL, Error>] = [:]
+
+    init(agentRoot: URL) { self.agentRoot = agentRoot }
+
+    /// Resolve `avatarID` to a usable .imx path, downloading from
+    /// `modelURL` if necessary. Concurrent calls for the same avatarID
+    /// coalesce onto a single download Task.
+    func resolve(avatarID: String, modelURL: URL?) async throws -> URL {
+        if let hit = scan(avatarID: avatarID) { return hit }
+
+        if let task = inflight[avatarID] {
+            return try await task.value
+        }
+        guard let modelURL else {
+            throw ModelError.notFound(avatarID: avatarID, root: agentRoot.path)
+        }
+        let task = Task<URL, Error> { [agentRoot] in
+            try await Self.download(modelURL: modelURL, into: agentRoot, avatarID: avatarID)
+        }
+        inflight[avatarID] = task
+        defer { inflight[avatarID] = nil }
+        return try await task.value
+    }
+
+    private func scan(avatarID: String) -> URL? {
+        let dir = agentRoot.appendingPathComponent(avatarID)
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: nil
+        ) else { return nil }
+        return entries.first(where: { $0.pathExtension == "imx" })
+    }
+
+    private static func download(modelURL: URL, into agentRoot: URL, avatarID: String) async throws -> URL {
+        let dir = agentRoot.appendingPathComponent(avatarID)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let dest = dir.appendingPathComponent("model.imx")
+        let tmp  = dir.appendingPathComponent(".model.imx.downloading")
+
+        do {
+            let (downloaded, _) = try await URLSession.shared.download(from: modelURL)
+            // Atomic rename over `dest` — replaces any partial leftover.
+            _ = try FileManager.default.replaceItemAt(dest, withItemAt: downloaded)
+            try? FileManager.default.removeItem(at: tmp)
+        } catch {
+            try? FileManager.default.removeItem(at: tmp)
+            throw ModelError.downloadFailed(modelURL, underlying: error)
+        }
+        return dest
+    }
+}

--- a/Examples/swift/essence-server/Sources/EssenceServer/main.swift
+++ b/Examples/swift/essence-server/Sources/EssenceServer/main.swift
@@ -1,0 +1,413 @@
+// EssenceServer — drop-in Swift replacement for platform/services/essence-avatar.
+//
+// Hosts N concurrent `EssenceRuntime` instances. Each /launch request joins a
+// LiveKit room as a participant, subscribes to the bot's TTS audio (published
+// by agent-worker), pipes it through bitHumanKit's Essence runtime, and
+// publishes the resulting lip-synced video back to the same room.
+//
+// Running:
+//   swift build -c release --product essence-server
+//   ./.build/release/essence-server --port 8089 --agent-root ~/agents
+//
+// Same wire protocol as the Python dispatcher:
+//   POST /launch   form: avatar_id, room_name, livekit_url, livekit_token,
+//                        async_mode, model_url, tags, api_secret, user_id
+//   GET  /health   { status: "ok" }
+//   GET  /ready    { status: "ok" }   (503 when at capacity, body still ok)
+//   GET  /status   { mode, pool_size, active_workers, idle_workers,
+//                    available_slots, at_capacity, rooms, active_rooms }
+
+import Foundation
+import Hummingbird
+import LiveKit
+import bitHumanKit
+
+// MARK: - CLI
+
+struct CLIOpts: Sendable {
+    var port: Int = 8089
+    var host: String = "0.0.0.0"
+    var agentRoot: String = NSHomeDirectory() + "/agents"
+    var maxSessions: Int = 32
+
+    static func parse() -> CLIOpts {
+        var o = CLIOpts()
+        let raw = Array(CommandLine.arguments.dropFirst())
+        var i = 0
+        while i < raw.count {
+            let a = raw[i]; defer { i += 1 }
+            switch a {
+            case "--port":         i += 1; o.port = Int(raw[i]) ?? o.port
+            case "--host":         i += 1; o.host = raw[i]
+            case "--agent-root":   i += 1; o.agentRoot = raw[i]
+            case "--max-sessions": i += 1; o.maxSessions = Int(raw[i]) ?? o.maxSessions
+            case "-h", "--help":
+                print("""
+                essence-server — Swift Essence runtime, LiveKit-participant edition.
+
+                  --port <N>           HTTP port (default 8089)
+                  --host <addr>        HTTP bind address (default 0.0.0.0)
+                  --agent-root <dir>   Where to look up <code>/model.imx (default ~/agents)
+                  --max-sessions <N>   Reject /launch beyond this (default 32)
+                """)
+                exit(0)
+            default:
+                FileHandle.standardError.write(Data("warning: ignored arg \(a)\n".utf8))
+            }
+        }
+        return o
+    }
+}
+
+// MARK: - Session registry
+
+actor SessionRegistry {
+    enum Slot {
+        case reserving                  // /launch in flight, no session yet
+        case active(EssenceSession)     // start() succeeded
+    }
+
+    let maxSessions: Int
+    private var slots: [String: Slot] = [:]
+
+    init(maxSessions: Int) { self.maxSessions = maxSessions }
+
+    func count() -> Int { slots.count }
+    func atCapacity() -> Bool { slots.count >= maxSessions }
+    func rooms() -> [String] { Array(slots.keys).sorted() }
+
+    /// Reserve a slot for `room`. Returns false if at capacity OR the
+    /// room is already in use (race-safe gate; caller responds 503).
+    func reserve(room: String) -> Bool {
+        guard slots.count < maxSessions, slots[room] == nil else { return false }
+        slots[room] = .reserving
+        return true
+    }
+
+    /// Promote a reservation to an active session once `start()`
+    /// returned successfully.
+    func attach(room: String, session: EssenceSession) {
+        slots[room] = .active(session)
+    }
+
+    /// Free the slot. Returns the active session if any, so the caller
+    /// can finalize. Idempotent.
+    func release(room: String) -> EssenceSession? {
+        let prior = slots.removeValue(forKey: room)
+        if case .active(let s) = prior { return s }
+        return nil
+    }
+}
+
+// MARK: - Wire types
+
+struct HealthResp: Encodable { let status: String }
+
+struct StatusResp: Encodable {
+    let mode: String
+    let pool_size: Int
+    let active_workers: Int
+    let idle_workers: Int
+    let available_slots: Int
+    let at_capacity: Bool
+    let rooms: [String]
+    let active_rooms: [String]
+}
+
+struct LaunchSuccess: Encodable {
+    let status: String
+    let message: String
+    let mode: String
+    let isAsync: Bool
+    let duration: Double
+    let request_id: String
+    let dispatch_time: Double
+    enum CodingKeys: String, CodingKey {
+        case status, message, mode
+        case isAsync = "async"
+        case duration, request_id, dispatch_time
+    }
+}
+
+struct ErrorResp: Encodable { let detail: String }
+
+// MARK: - Form parsing
+
+/// Parse `application/x-www-form-urlencoded` into a flat dict.
+/// Tolerant: silently skips malformed pairs.
+func parseForm(_ s: String) -> [String: String] {
+    var out: [String: String] = [:]
+    for pair in s.split(separator: "&", omittingEmptySubsequences: true) {
+        guard let eq = pair.firstIndex(of: "=") else { continue }
+        let kRaw = String(pair[..<eq])
+        let vRaw = String(pair[pair.index(after: eq)...]).replacingOccurrences(of: "+", with: " ")
+        let k = kRaw.removingPercentEncoding ?? kRaw
+        let v = vRaw.removingPercentEncoding ?? vRaw
+        out[k] = v
+    }
+    return out
+}
+
+struct LaunchForm {
+    let livekitURL: String
+    let livekitToken: String
+    let roomName: String
+    let avatarID: String        // "*" if caller omitted
+    let isAsync: Bool
+    let modelURL: URL?
+    let tags: String?
+    let apiSecret: String?
+    let userID: String?
+
+    static func parse(_ form: [String: String]) throws -> LaunchForm {
+        func required(_ k: String) throws -> String {
+            guard let v = form[k], !v.isEmpty else {
+                throw FormError.missing(k)
+            }
+            return v
+        }
+        let asyncRaw = (form["async_mode"] ?? "false").lowercased()
+        let isAsync = (asyncRaw == "true" || asyncRaw == "1" || asyncRaw == "yes")
+        return LaunchForm(
+            livekitURL:   try required("livekit_url"),
+            livekitToken: try required("livekit_token"),
+            roomName:     try required("room_name"),
+            avatarID:     form["avatar_id"].flatMap { $0.isEmpty ? nil : $0 } ?? "*",
+            isAsync:      isAsync,
+            modelURL:     form["model_url"].flatMap { URL(string: $0) },
+            tags:         form["tags"],
+            apiSecret:    form["api_secret"],
+            userID:       form["user_id"]
+        )
+    }
+
+    enum FormError: Error, CustomStringConvertible {
+        case missing(String)
+        var description: String {
+            switch self { case .missing(let k): return "missing required field: \(k)" }
+        }
+    }
+}
+
+// MARK: - JSON helper
+
+func jsonResponse<T: Encodable>(_ value: T, status: HTTPResponse.Status = .ok) -> Response {
+    let data: Data
+    do {
+        data = try JSONEncoder().encode(value)
+    } catch {
+        let fallback = #"{"detail":"internal: failed to encode response"}"#
+        return Response(
+            status: .internalServerError,
+            headers: [.contentType: "application/json"],
+            body: .init(byteBuffer: .init(string: fallback))
+        )
+    }
+    return Response(
+        status: status,
+        headers: [.contentType: "application/json"],
+        body: .init(byteBuffer: ByteBuffer(bytes: data))
+    )
+}
+
+// MARK: - HTTP
+
+struct EssenceServerMain {
+    static func main() async throws {
+        let opts = CLIOpts.parse()
+        // Set up the central config bag from CLI + env. Subsequent
+        // session-level code reads from EssenceServerConfig.shared
+        // instead of hard-coded constants. See Config.swift for the
+        // list of env vars (ESSENCE_FRAME_WIDTH, ESSENCE_FPS, etc.).
+        EssenceServerConfig.applyEnv(maxSessionsPerProcess: opts.maxSessions)
+
+        let registry = SessionRegistry(maxSessions: opts.maxSessions)
+        let modelStore = ModelStore(agentRoot: URL(fileURLWithPath: opts.agentRoot))
+        let fixtureCache = FixtureCache()
+
+        // Put the WebRTC ADM into manual rendering mode so the audio path
+        // never opens a real device. Multiple essence-server processes
+        // share one Mac and can't all claim the mic, so the no-device
+        // path is the only way to publish audio from N processes
+        // concurrently. Per-session, we let
+        // `LocalParticipant.setMicrophone(enabled: true)` bring the
+        // engine up — that is what the SDK's own
+        // `testManualRenderingModePublishAudio` does, and in manual
+        // rendering mode it doesn't claim the mic device.
+        do {
+            try AudioManager.shared.setManualRenderingMode(true)
+            FileHandle.standardError.write(Data(
+                "essence-server: manual rendering enabled (isManualRenderingMode=\(AudioManager.shared.isManualRenderingMode))\n".utf8))
+        } catch {
+            FileHandle.standardError.write(Data(
+                "essence-server: setManualRenderingMode failed: \(error) — audio republish will be silent\n".utf8))
+        }
+
+        let router = Router()
+
+        // /health is liveness-only — process is up and answering. Use
+        // it for "is the server breathing"; never for routing.
+        router.get("/health") { _, _ -> Response in
+            jsonResponse(HealthResp(status: "ok"))
+        }
+
+        // /ready is what the LB should use for traffic routing. Returns
+        // 200 only when:
+        //   * manual rendering mode is engaged (audio republish path
+        //     is operational; without it, audio publishes silently),
+        //   * the registry isn't at the per-process cap (otherwise
+        //     /launch will reject anyway, so don't waste the
+        //     handshake).
+        // 503 means "skip me" — the LB should retry on another
+        // instance. Different from /health which says "the process
+        // is alive" and is fine even when we can't accept work.
+        router.get("/ready") { _, _ -> Response in
+            let atCap = await registry.atCapacity()
+            let manualRendering = AudioManager.shared.isManualRenderingMode
+            let ready = !atCap && manualRendering
+            let detail = ready ? "ok" :
+                "atCap=\(atCap) manualRendering=\(manualRendering)"
+            return jsonResponse(HealthResp(status: detail),
+                                status: ready ? .ok : .serviceUnavailable)
+        }
+
+        // /metrics emits Prometheus-text format counters. Scrape with
+        //   curl http://moraga:8089/metrics
+        // No auth (HTTP-internal). Counters are process-local — each
+        // of the 8 instances has its own; aggregate via Prometheus's
+        // `sum by (instance) (...)`.
+        router.get("/metrics") { _, _ -> Response in
+            let body = EssenceMetrics.shared.renderPrometheus()
+            return Response(
+                status: .ok,
+                headers: [.contentType: "text/plain; version=0.0.4; charset=utf-8"],
+                body: .init(byteBuffer: ByteBuffer(string: body))
+            )
+        }
+
+        router.get("/status") { _, _ -> Response in
+            let n = await registry.count()
+            let rooms = await registry.rooms()
+            return jsonResponse(StatusResp(
+                mode: "swift-pool",
+                pool_size: opts.maxSessions,
+                active_workers: n,
+                idle_workers: max(0, opts.maxSessions - n),
+                available_slots: max(0, opts.maxSessions - n),
+                at_capacity: n >= opts.maxSessions,
+                rooms: rooms,
+                active_rooms: rooms
+            ))
+        }
+
+        router.post("/launch") { req, _ -> Response in
+            let t0 = Date()
+
+            // 1. Capacity gate (mirror Python: refuse early so the LB can reroute).
+            if await registry.atCapacity() {
+                return jsonResponse(ErrorResp(detail: "at capacity"),
+                                    status: .serviceUnavailable)
+            }
+
+            // 2. Parse form.
+            let raw = try await req.body.collect(upTo: 16 * 1024)
+            let bodyText = String(buffer: raw)
+            let form: LaunchForm
+            do {
+                form = try LaunchForm.parse(parseForm(bodyText))
+            } catch {
+                return jsonResponse(ErrorResp(detail: "\(error)"),
+                                    status: .badRequest)
+            }
+
+            // 3. Reserve a slot. Race-safe: registry rejects if cap was filled
+            //    between step 1 and now.
+            guard await registry.reserve(room: form.roomName) else {
+                return jsonResponse(ErrorResp(detail: "at capacity"),
+                                    status: .serviceUnavailable)
+            }
+
+            // 4. Resolve model on disk (download if needed). Releases the
+            //    slot on every error path so a bad request can't poison capacity.
+            let imxPath: URL
+            do {
+                imxPath = try await modelStore.resolve(
+                    avatarID: form.avatarID, modelURL: form.modelURL)
+            } catch let err as ModelStore.ModelError {
+                _ = await registry.release(room: form.roomName)
+                let status: HTTPResponse.Status = {
+                    if case .notFound = err { return .badRequest }
+                    return .internalServerError
+                }()
+                return jsonResponse(ErrorResp(detail: "\(err)"), status: status)
+            } catch {
+                _ = await registry.release(room: form.roomName)
+                return jsonResponse(ErrorResp(detail: "model resolve: \(error)"),
+                                    status: .internalServerError)
+            }
+
+            // 5. Warm the shared fixture (one-time per avatarID) and
+            //    grab the reference; the session builds its own runtime
+            //    off it via `Bithuman.createRuntime(fixture:)`.
+            let fixture: EssenceFixture
+            do {
+                fixture = try await fixtureCache.get(avatarID: form.avatarID, imxPath: imxPath)
+            } catch {
+                _ = await registry.release(room: form.roomName)
+                return jsonResponse(ErrorResp(detail: "fixture: \(error)"),
+                                    status: .internalServerError)
+            }
+
+            // 6. Build session, connect to LiveKit, publish video. Sync
+            //    mode (matches Python pool-mode): block on start() so the
+            //    caller has backpressure-correct success semantics.
+            let session = EssenceSession(
+                roomName: form.roomName,
+                fixture: fixture,
+                onTerminate: { name in
+                    _ = await registry.release(room: name)
+                    EssenceMetrics.shared.incrSessionsTerminated()
+                    EssenceMetrics.shared.setActiveSessions(UInt64(await registry.count()))
+                }
+            )
+            do {
+                try await session.start(url: form.livekitURL, token: form.livekitToken)
+                EssenceMetrics.shared.incrSessionsStarted()
+                EssenceMetrics.shared.setActiveSessions(UInt64(await registry.count()))
+            } catch {
+                EssenceMetrics.shared.incrLaunchFailed()
+                // start() failed → release the slot. The session itself is
+                // dead in the water; no need to call stop() since start()
+                // is responsible for its own partial-state cleanup on throw.
+                _ = await registry.release(room: form.roomName)
+                return jsonResponse(ErrorResp(detail: "session start: \(error)"),
+                                    status: .internalServerError)
+            }
+            await registry.attach(room: form.roomName, session: session)
+
+            let dispatchTime = Date().timeIntervalSince(t0)
+            return jsonResponse(LaunchSuccess(
+                status: "success",
+                message: "Avatar worker launched/dispatched for room: \(form.roomName)",
+                mode: "swift-pool",
+                isAsync: form.isAsync,
+                duration: dispatchTime,
+                request_id: "\(form.roomName)-\(Int(t0.timeIntervalSince1970 * 1000))",
+                dispatch_time: dispatchTime
+            ))
+        }
+
+        let app = Application(
+            router: router,
+            configuration: .init(address: .hostname(opts.host, port: opts.port),
+                                 serverName: "essence-server")
+        )
+
+        FileHandle.standardError.write(Data(
+            "essence-server listening on \(opts.host):\(opts.port) (max sessions \(opts.maxSessions); agents at \(opts.agentRoot))\n".utf8))
+
+        try await app.runService()
+    }
+}
+
+try await EssenceServerMain.main()

--- a/Examples/swift/hello-voice-chat/Package.swift
+++ b/Examples/swift/hello-voice-chat/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+// HelloVoiceChat — the minimum it takes to embed bitHumanKit into an
+// SPM-built macOS executable: a voice agent with no avatar and no
+// billing. See README.md to run.
+let package = Package(
+    name: "HelloVoiceChat",
+    platforms: [
+        .macOS("26.0")
+    ],
+    dependencies: [
+        .package(name: "bithuman",
+                 url: "https://github.com/bithuman-product/bithuman-sdk-public.git",
+                 from: "0.8.1")
+    ],
+    targets: [
+        .executableTarget(
+            name: "HelloVoiceChat",
+            dependencies: [
+                .product(name: "bitHumanKit", package: "bithuman")
+            ],
+            path: "Sources/HelloVoiceChat",
+            swiftSettings: [.swiftLanguageMode(.v5)]
+        )
+    ]
+)

--- a/Examples/swift/hello-voice-chat/README.md
+++ b/Examples/swift/hello-voice-chat/README.md
@@ -1,0 +1,23 @@
+# HelloVoiceChat
+
+The minimum it takes to embed `bitHumanKit` into an SPM-built macOS
+executable: a voice agent with no avatar and no billing. STT + LLM + TTS
+all run on-device.
+
+## Run
+
+```bash
+cd Examples/swift/hello-voice-chat
+swift run -c release HelloVoiceChat
+```
+
+Speak into the mic; Ctrl-C to quit. Override any field on
+`VoiceChatConfig` (system prompt, language, voice) before passing it to
+`VoiceChat`.
+
+## Requires
+
+- macOS 26+ (Tahoe), Apple Silicon M3+
+- Microphone permission (granted on first launch)
+
+No API key, no model file: the voice path is unmetered.

--- a/Examples/swift/hello-voice-chat/Sources/HelloVoiceChat/main.swift
+++ b/Examples/swift/hello-voice-chat/Sources/HelloVoiceChat/main.swift
@@ -1,0 +1,23 @@
+// The minimum it takes to embed bitHumanKit into another
+// SPM-built macOS executable. Run after `./build-example.sh`.
+import bitHumanKit
+import Foundation
+
+@main
+struct HelloVoiceChat {
+    static func main() async throws {
+        // Default config: bundled cloned voice, en-US, built-in
+        // friendly-assistant prompt. Override any field on
+        // `VoiceChatConfig` before passing it in.
+        var config = VoiceChatConfig()
+        config.systemPrompt = "You are a deadpan ship's computer. One-sentence answers."
+
+        let chat = await MainActor.run { VoiceChat(config: config) }
+        try await chat.start()
+
+        // Park forever; Ctrl-C tears the process down.
+        let forever = AsyncStream<Void> { _ in }
+        for await _ in forever { break }
+        _ = chat
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,24 +1,59 @@
 // swift-tools-version: 6.0
 // bitHumanKit — public binary distribution.
 //
-// The source for bitHumanKit lives in the swift/ tree of the private
-// monorepo bithuman-product/bithuman-sdk (formerly the standalone
-// bithuman-product/bithuman-kit before the 2026-05-05 consolidation).
-// This package consumes the pre-compiled XCFramework attached to
-// THIS repo's GitHub Releases via SwiftPM's binaryTarget — the
-// `.xcframework.zip` is built from bithuman-sdk and uploaded here
-// per release; consumers depend only on this package URL.
+// The source for these frameworks lives in the private monorepo
+// bithuman-product/bithuman-sdk (the swift/ tree for bitHumanKit; the
+// engine/expression/ and sdks/swift/ trees for the two Layer-1 engine
+// products extracted on the refactor/engine-tiers branch). This package
+// consumes the pre-compiled XCFrameworks attached to THIS repo's GitHub
+// Releases via SwiftPM's binaryTarget — each `.xcframework.zip` is built
+// from bithuman-sdk and uploaded here per release; consumers depend only
+// on this package URL.
 //
 // All third-party deps (MLX, HuggingFace, Tokenizers, …) are
-// statically linked into the framework binary, so consumers
+// statically linked into the framework binaries, so consumers
 // don't need any transitive Swift Package dependencies. Just
-// add this package and `import bitHumanKit`.
+// add this package and `import bitHumanKit` (or `import Expression`
+// / `import Bithuman` for the lower-level engine products).
+//
+// Products
+//   - bitHumanKit  Full on-device voice + video chat SDK (umbrella).
+//                  Re-exports the Expression avatar engine + the Essence
+//                  (libessence) runtime + the on-device LLM/TTS stack.
+//                  Most apps want this one. `import bitHumanKit`.
+//   - Expression   Layer-1 avatar engine on its own: Wav2Vec2 → DiT →
+//                  VAE → ANE expressive talking head. Built from the
+//                  bithuman-sdk engine/expression/ package. Pull this in
+//                  directly when you only need the avatar renderer (no
+//                  STT/LLM/TTS). Home of the `Bithuman` actor,
+//                  `Bithuman.Quality`, `AvatarConfig`, `ImxContainer`.
+//                  `import Expression`.
+//   - Bithuman     Layer-1 Essence engine on its own: the portable
+//                  libessence C++ avatar runtime (audio → composited BGR
+//                  frames from a pre-built `.imx`). Built from the
+//                  bithuman-sdk sdks/swift/ package. CPU-only, works on
+//                  any Apple Silicon. `import Bithuman`.
 //
 // Hardware floor (gated at runtime via HardwareCheck.evaluate()):
 //   macOS:   M3+ Apple Silicon, macOS 26 (Tahoe)
 //   iPad:    iPad Pro M4+, 16 GB unified memory, iPadOS 26
 //   iPhone:  iPhone 16 Pro+ (A18 Pro), iOS 26
+//
+// RELEASE NOTE (binaryTarget checksums):
+//   The `bitHumanKit` slice ships today (v0.8.1). The `Expression` and
+//   `Bithuman` (Essence) slices are wired here against the SAME release
+//   tag but their checksums below are PLACEHOLDERS — they must be filled
+//   in by the release flow (scripts/build-binary-xcframework.sh emits the
+//   per-product zips; `swift package compute-checksum <zip>` yields the
+//   value). Until a release uploads those two zips + updates these
+//   checksums, only the `bitHumanKit` product resolves. See
+//   scripts/validate-release.sh and docs/RELEASE_MATRIX.md.
 import PackageDescription
+
+// Pin every binary slice to the same release tag so a `from:` bump moves
+// all three products in lockstep.
+let releaseTag = "v0.8.1"
+let releaseBase = "https://github.com/bithuman-product/bithuman-sdk-public/releases/download/\(releaseTag)"
 
 let package = Package(
     name: "bithuman",
@@ -28,12 +63,30 @@ let package = Package(
     ],
     products: [
         .library(name: "bitHumanKit", targets: ["bitHumanKit"]),
+        .library(name: "Expression", targets: ["Expression"]),
+        .library(name: "Bithuman", targets: ["Bithuman"]),
     ],
     targets: [
         .binaryTarget(
             name: "bitHumanKit",
-            url: "https://github.com/bithuman-product/bithuman-sdk-public/releases/download/v0.8.1/bitHumanKit.xcframework.zip",
+            url: "\(releaseBase)/bitHumanKit.xcframework.zip",
             checksum: "5c536e37919b693591dff234db8627c01952ae24ae58651aeacbd875bd78e9db"
+        ),
+        // Layer-1 avatar engine (engine/expression). PLACEHOLDER checksum —
+        // filled in by the release flow once Expression.xcframework.zip is
+        // built + uploaded to the release tag above.
+        .binaryTarget(
+            name: "Expression",
+            url: "\(releaseBase)/Expression.xcframework.zip",
+            checksum: "0000000000000000000000000000000000000000000000000000000000000000"
+        ),
+        // Layer-1 Essence engine (sdks/swift, libessence). PLACEHOLDER
+        // checksum — filled in by the release flow once
+        // Bithuman.xcframework.zip is built + uploaded to the release tag.
+        .binaryTarget(
+            name: "Bithuman",
+            url: "\(releaseBase)/Bithuman.xcframework.zip",
+            checksum: "0000000000000000000000000000000000000000000000000000000000000000"
         ),
     ]
 )

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+# =============================================================================
+# validate-release.sh — completeness + sanity check for a published `bithuman`
+#                        PyPI release, across the whole target matrix.
+#
+# WHY THIS EXISTS (motivating incident):
+#   Releases 1.12.0 through 1.17.3 silently shipped ONLY:
+#       - cp311 wheels for Linux (manylinux_2_28 x86_64 + aarch64)
+#       - cp313 wheel for macOS arm64
+#   Every other interpreter (cp39 / cp310 / cp312, all macOS non-3.13, etc.)
+#   404'd on a plain `pip install bithuman` for the affected Python. No sdist
+#   exists (intentional), so a missing wheel == an uninstallable package for
+#   that interpreter, with zero signal at publish time. This script makes that
+#   class of gap a hard, loud, non-zero-exit failure.
+#
+# SINGLE SOURCE OF TRUTH:
+#   The EXPECTED_PYTAGS / EXPECTED_PLATFORMS config block below is THE matrix.
+#   When macOS Intel (macosx_*_x86_64), Windows, or a new Python minor lands,
+#   edit ONLY that block — everything else derives from it.
+#
+# USAGE:
+#   scripts/validate-release.sh [VERSION]
+#       VERSION   bithuman version to validate. Default: latest on PyPI.
+#
+# EXIT CODES:
+#   0  all phases passed
+#   1  Phase 1 coverage gap (a required {pytag}x{platform} wheel is missing)
+#   2  Phase 2 install failure (a locally-available Python could not install /
+#      import the package)
+#   3  Phase 3 example smoke failure
+# =============================================================================
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# CONFIG BLOCK — THE SINGLE SOURCE OF TRUTH. Edit here when the matrix changes.
+# -----------------------------------------------------------------------------
+
+# Python minors that MUST have a wheel. (pytag form: cp39 == Python 3.9)
+EXPECTED_PYTAGS=(cp39 cp310 cp311 cp312 cp313)
+
+# Platform tags that MUST be present for EACH pytag above.
+# A wheel's platform tag is matched as a SUBSTRING (PyPI bakes the macOS
+# deployment target into the tag, e.g. macosx_26_0_arm64), so we list the
+# stable, version-independent fragment here.
+#
+# Currently shipping:
+EXPECTED_PLATFORMS=(
+  "macosx_*_arm64"            # macOS Apple Silicon
+  "manylinux_2_28_x86_64"     # Linux x86_64
+  "manylinux_2_28_aarch64"    # Linux aarch64
+)
+# NOT YET SHIPPING — uncomment as each target's wheels start publishing:
+#   "macosx_*_x86_64"         # macOS Intel  (being added separately)
+#   "win_amd64"               # Windows x86_64
+#   "win_arm64"               # Windows arm64
+
+# Map pytag -> the X.Y string `uv` understands.
+pytag_to_xy() {
+  case "$1" in
+    cp39)  echo "3.9"  ;;
+    cp310) echo "3.10" ;;
+    cp311) echo "3.11" ;;
+    cp312) echo "3.12" ;;
+    cp313) echo "3.13" ;;
+    cp314) echo "3.14" ;;
+    *)     echo "" ;;
+  esac
+}
+
+# Public-repo Examples root (read-only; we only smoke-test imports).
+# Derived from this script's location — it lives in scripts/ at the repo
+# root, so the examples are one level up. Override with the
+# BITHUMAN_EXAMPLES_REPO env var when running the script from outside a
+# checkout (e.g. against a separate clone).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLES_REPO="${BITHUMAN_EXAMPLES_REPO:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+
+# -----------------------------------------------------------------------------
+# Internals
+# -----------------------------------------------------------------------------
+PKG="bithuman"
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/validate-release.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+banner() {
+  printf '\n'
+  printf '=%.0s' {1..78}; printf '\n'
+  printf '  %s\n' "$1"
+  printf '=%.0s' {1..78}; printf '\n'
+}
+
+section() { printf '\n--- %s ---\n' "$1"; }
+
+# Resolve version (arg or PyPI latest).
+RESOLVED_JSON="$WORKDIR/pypi.json"
+if ! curl -fsS "https://pypi.org/pypi/${PKG}/json" -o "$RESOLVED_JSON"; then
+  echo "FATAL: could not reach PyPI JSON API for ${PKG}" >&2
+  exit 2
+fi
+
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+  VERSION="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["info"]["version"])' "$RESOLVED_JSON")"
+fi
+
+banner "bithuman release validation — version ${VERSION}"
+echo "PyPI:      https://pypi.org/project/${PKG}/${VERSION}/"
+echo "Workdir:   ${WORKDIR}"
+echo "Matrix:    ${#EXPECTED_PYTAGS[@]} pytags x ${#EXPECTED_PLATFORMS[@]} platforms = $(( ${#EXPECTED_PYTAGS[@]} * ${#EXPECTED_PLATFORMS[@]} )) required wheels"
+
+# Pull the filename list for this exact version.
+WHEEL_LIST="$WORKDIR/wheels.txt"
+python3 - "$RESOLVED_JSON" "$VERSION" > "$WHEEL_LIST" <<'PY'
+import json, sys
+data = json.load(open(sys.argv[1]))
+ver = sys.argv[2]
+files = data.get("releases", {}).get(ver, [])
+for f in sorted(x["filename"] for x in files):
+    print(f)
+PY
+
+if [[ ! -s "$WHEEL_LIST" ]]; then
+  echo "FATAL: version ${VERSION} has NO files published on PyPI." >&2
+  exit 1
+fi
+
+# =============================================================================
+# PHASE 1 — COVERAGE
+# =============================================================================
+banner "PHASE 1 — wheel coverage"
+echo "Published files for ${VERSION}:"
+sed 's/^/  /' "$WHEEL_LIST"
+
+# Glob-match helper: does any published filename contain pytag AND match the
+# platform fragment (which may contain a '*' wildcard for the macOS target)?
+wheel_present() {
+  local pytag="$1" plat="$2" line
+  while IFS= read -r line; do
+    [[ "$line" == *.whl ]] || continue
+    [[ "$line" == *"-${pytag}-"* ]] || continue
+    # shellcheck disable=SC2053
+    if [[ "$line" == *${plat}.whl ]]; then
+      return 0
+    fi
+  done < "$WHEEL_LIST"
+  return 1
+}
+
+section "PASS / MISS matrix"
+printf '  %-8s %-26s %s\n' "PYTAG" "PLATFORM" "RESULT"
+printf '  %-8s %-26s %s\n' "-----" "--------" "------"
+
+COVERAGE_MISSES=0
+for pytag in "${EXPECTED_PYTAGS[@]}"; do
+  for plat in "${EXPECTED_PLATFORMS[@]}"; do
+    if wheel_present "$pytag" "$plat"; then
+      printf '  %-8s %-26s PASS\n' "$pytag" "$plat"
+    else
+      printf '  %-8s %-26s *** MISS ***\n' "$pytag" "$plat"
+      COVERAGE_MISSES=$(( COVERAGE_MISSES + 1 ))
+    fi
+  done
+done
+
+if (( COVERAGE_MISSES > 0 )); then
+  echo
+  echo "PHASE 1 RESULT: FAIL — ${COVERAGE_MISSES} required wheel(s) missing."
+  echo "This is exactly the 1.12.0–1.17.3 regression class (silent partial"
+  echo "interpreter coverage). Affected interpreters cannot 'pip install ${PKG}'."
+else
+  echo
+  echo "PHASE 1 RESULT: PASS — all $(( ${#EXPECTED_PYTAGS[@]} * ${#EXPECTED_PLATFORMS[@]} )) required wheels present."
+fi
+
+# =============================================================================
+# PHASE 2 — INSTALLABILITY (local, uv venvs only — never system/conda Python)
+# =============================================================================
+banner "PHASE 2 — installability (isolated uv venvs)"
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv not found on PATH — cannot run Phase 2. Treating all as SKIPPED."
+fi
+
+INSTALL_FAILURES=0
+INSTALL_OK=0
+INSTALL_SKIPPED=0
+SUMMARY_PHASE2=()
+
+# A venv we can reuse for Phase 3 (first successful install).
+PHASE3_VENV=""
+PHASE3_XY=""
+
+for pytag in "${EXPECTED_PYTAGS[@]}"; do
+  XY="$(pytag_to_xy "$pytag")"
+  if [[ -z "$XY" ]]; then
+    echo "  ${pytag}: no X.Y mapping — SKIPPED"
+    SUMMARY_PHASE2+=("${pytag}: SKIPPED (no version mapping)")
+    INSTALL_SKIPPED=$(( INSTALL_SKIPPED + 1 ))
+    continue
+  fi
+
+  section "Python ${XY} (${pytag})"
+
+  if ! command -v uv >/dev/null 2>&1; then
+    echo "  uv unavailable — SKIPPED"
+    SUMMARY_PHASE2+=("${pytag} (py${XY}): SKIPPED (no uv)")
+    INSTALL_SKIPPED=$(( INSTALL_SKIPPED + 1 ))
+    continue
+  fi
+
+  VENV="$WORKDIR/venv-${pytag}"
+  # `uv venv --python X.Y` only uses an already-obtainable interpreter when we
+  # forbid downloads; if not present locally we SKIP (don't fail) per spec.
+  if ! UV_PYTHON_DOWNLOADS=never uv venv --python "$XY" "$VENV" >/dev/null 2>&1; then
+    echo "  Python ${XY} not locally obtainable via uv — SKIPPED"
+    SUMMARY_PHASE2+=("${pytag} (py${XY}): SKIPPED (interpreter not local)")
+    INSTALL_SKIPPED=$(( INSTALL_SKIPPED + 1 ))
+    continue
+  fi
+  echo "  venv created: ${VENV}"
+
+  if ! uv pip install --python "$VENV/bin/python" "${PKG}==${VERSION}" >/dev/null 2>&1; then
+    echo "  *** pip install ${PKG}==${VERSION} FAILED on Python ${XY} ***"
+    SUMMARY_PHASE2+=("${pytag} (py${XY}): FAIL (install)")
+    INSTALL_FAILURES=$(( INSTALL_FAILURES + 1 ))
+    continue
+  fi
+  echo "  installed ${PKG}==${VERSION}"
+
+  # Import + API-surface smoke (mirrors build-wheel-in-container.sh smoke test).
+  if BITHUMAN_UNMETERED=1 "$VENV/bin/python" - <<'PY'
+import bithuman
+from bithuman import Avatar          # core class must import
+from bithuman import AsyncBithuman   # async runtime entrypoint
+from bithuman import AudioChunk, VideoFrame, VideoControl
+print(f"OK: bithuman {bithuman.__version__} ABI={getattr(bithuman,'__abi_version__','?')}")
+print("API surface OK: Avatar / AsyncBithuman / AudioChunk / VideoFrame / VideoControl")
+PY
+  then
+    echo "  smoke: PASS"
+    SUMMARY_PHASE2+=("${pytag} (py${XY}): PASS")
+    INSTALL_OK=$(( INSTALL_OK + 1 ))
+    if [[ -z "$PHASE3_VENV" ]]; then
+      PHASE3_VENV="$VENV"
+      PHASE3_XY="$XY"
+    fi
+  else
+    echo "  *** import / API-surface smoke FAILED on Python ${XY} ***"
+    SUMMARY_PHASE2+=("${pytag} (py${XY}): FAIL (smoke)")
+    INSTALL_FAILURES=$(( INSTALL_FAILURES + 1 ))
+  fi
+done
+
+echo
+echo "PHASE 2 RESULT: ${INSTALL_OK} PASS / ${INSTALL_FAILURES} FAIL / ${INSTALL_SKIPPED} SKIPPED"
+
+# =============================================================================
+# PHASE 3 — EXAMPLE SMOKE (imports only; no network / auth / model files)
+# =============================================================================
+banner "PHASE 3 — vanilla example smoke"
+
+PHASE3_STATUS="SKIPPED"
+EXAMPLE_USED=""
+
+if [[ -z "$PHASE3_VENV" ]]; then
+  echo "No installed venv available from Phase 2 — SKIPPED."
+else
+  # Simplest local Essence example: quickstart/local-avatar.py — minimal deps
+  # (bithuman + opencv-python-headless), no LiveKit/OpenAI stack.
+  EX_DIR="${EXAMPLES_REPO}/Examples/quickstart"
+  EX_FILE="${EX_DIR}/local-avatar.py"
+  REQ_MINIMAL=(opencv-python-headless)   # bithuman already installed in venv
+
+  if [[ ! -f "$EX_FILE" ]]; then
+    # Fallback to the local-essence quickstart if the layout differs.
+    EX_DIR="${EXAMPLES_REPO}/Examples/python/local-essence"
+    EX_FILE="${EX_DIR}/quickstart.py"
+  fi
+
+  if [[ ! -f "$EX_FILE" ]]; then
+    echo "Could not locate a simple local example under ${EXAMPLES_REPO} — SKIPPED."
+  else
+    echo "Example:    ${EX_FILE}"
+    echo "Venv:       ${PHASE3_VENV} (Python ${PHASE3_XY})"
+    echo "Exercising: install minimal deps + resolve the example's imports"
+    echo "            (NO model file / NO API secret / NO network calls)"
+
+    if uv pip install --python "$PHASE3_VENV/bin/python" "${REQ_MINIMAL[@]}" >/dev/null 2>&1; then
+      echo "  installed minimal example deps: ${REQ_MINIMAL[*]}"
+    else
+      echo "  WARNING: could not install ${REQ_MINIMAL[*]} — attempting import check anyway"
+    fi
+
+    # The example calls argparse + AsyncBithuman.create() which needs a model
+    # file & auth at *runtime*; we never reach that. We only assert that every
+    # top-level import the example performs resolves in the installed wheel +
+    # its declared deps. Python compiles the whole module on import, so we
+    # exec the import lines extracted from the example.
+    if EX_FILE="$EX_FILE" BITHUMAN_UNMETERED=1 "$PHASE3_VENV/bin/python" - <<'PY'
+import ast, importlib, os, sys
+
+ex = os.environ["EX_FILE"]
+src = open(ex).read()
+tree = ast.parse(src, ex)
+
+mods = set()
+for node in ast.walk(tree):
+    if isinstance(node, ast.Import):
+        for a in node.names:
+            mods.add(a.name.split(".")[0])
+    elif isinstance(node, ast.ImportFrom):
+        if node.module and node.level == 0:
+            mods.add(node.module.split(".")[0])
+
+# Stdlib / always-present — not part of the wheel contract.
+ignore = {"argparse", "asyncio", "os", "threading", "sys", "ast",
+          "importlib", "json", "time", "pathlib", "typing"}
+checked, failed = [], []
+for m in sorted(mods - ignore):
+    try:
+        importlib.import_module(m)
+        checked.append(m)
+    except Exception as e:  # noqa: BLE001
+        failed.append(f"{m} ({e.__class__.__name__}: {e})")
+
+print(f"example: {os.path.basename(ex)}")
+print(f"imports resolved: {', '.join(checked) if checked else '(none)'}")
+if failed:
+    print(f"imports FAILED: {'; '.join(failed)}")
+    sys.exit(1)
+print("EXAMPLE IMPORT SMOKE: PASS")
+PY
+    then
+      PHASE3_STATUS="PASS"
+      EXAMPLE_USED="$EX_FILE"
+      echo "PHASE 3 RESULT: PASS"
+    else
+      PHASE3_STATUS="FAIL"
+      EXAMPLE_USED="$EX_FILE"
+      echo "PHASE 3 RESULT: FAIL — example imports do not resolve against the wheel"
+    fi
+  fi
+fi
+
+# =============================================================================
+# FINAL SUMMARY
+# =============================================================================
+banner "SUMMARY — bithuman ${VERSION}"
+
+echo "Phase 1 (coverage):"
+if (( COVERAGE_MISSES > 0 )); then
+  echo "  FAIL — ${COVERAGE_MISSES} required wheel(s) MISSING (see matrix above)"
+else
+  echo "  PASS — full ${#EXPECTED_PYTAGS[@]}x${#EXPECTED_PLATFORMS[@]} wheel matrix present"
+fi
+
+echo "Phase 2 (installability):"
+echo "  ${INSTALL_OK} PASS / ${INSTALL_FAILURES} FAIL / ${INSTALL_SKIPPED} SKIPPED"
+for line in "${SUMMARY_PHASE2[@]:-}"; do
+  [[ -n "$line" ]] && echo "    - $line"
+done
+
+echo "Phase 3 (example smoke):"
+echo "  ${PHASE3_STATUS}${EXAMPLE_USED:+ — $EXAMPLE_USED}"
+
+# Exit code precedence: coverage > install > example.
+EXIT=0
+if (( COVERAGE_MISSES > 0 )); then
+  EXIT=1
+elif (( INSTALL_FAILURES > 0 )); then
+  EXIT=2
+elif [[ "$PHASE3_STATUS" == "FAIL" ]]; then
+  EXIT=3
+fi
+
+echo
+echo "OVERALL: $( ((EXIT==0)) && echo 'PASS' || echo "FAIL (exit ${EXIT})" )"
+exit "$EXIT"


### PR DESCRIPTION
## Single-source examples + expose engine products + re-enable mirror

- Consolidated the Swift dev/example tools (`BenchEssence`, `EssenceServer`, `HelloVoiceChat`, `Compare{LLM,DiT,TTS}`) into `Examples/swift/` as the single source of truth
- `Package.swift` exposes the `Expression` + `Bithuman` products from GitHub-Release xcframeworks
- Re-enabled the disabled `bump-docs.yml` mirror sync (needs `MIRROR_RELEASE_PAT`); de-hardcoded absolute paths in release scripts

**Needs CI:** build the relocated `Examples/swift/*` against the published `Expression`/`Bithuman` binaryTargets. Depends on `bithuman-sdk` publishing those products.

Draft until upstream products publish.
