### PR TITLE
chore(ci+docs): retire dead docs/ branch after Mintlify migration

### DIFF
--- a/.github/workflows/bump-docs.yml
+++ b/.github/workflows/bump-docs.yml
@@ -44,10 +44,16 @@
 #
 # What the job does:
 #   1. Resolves the libessence version from the dispatch payload or input.
-#   2. Scans docs/ and python/README.md, derives the OLD version from the
-#      highest currently-pinned semver across those paths.
-#   3. Replaces every OLD -> NEW occurrence in those paths.
+#   2. Scans python/README.md, derives the OLD version from the highest
+#      currently-pinned semver there.
+#   3. Replaces every OLD -> NEW occurrence in that file.
 #   4. Opens a PR (does NOT auto-merge — a human reviews the doc edits).
+#
+# NOTE (2026-05-29): the Mintlify docs/ tree was RETIRED from this repo;
+#   all documentation now lives in bithuman-product/public-docs (Astro,
+#   served at docs.bithuman.ai). Version pins inside those docs are the
+#   public-docs repo's responsibility — this workflow only bumps the
+#   python/README.md PyPI landing page that still lives here.
 #
 # Idempotent: if OLD == NEW the job exits before opening a PR. If a
 # bump-docs PR is already open against the same NEW version, the job
@@ -111,25 +117,30 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Derive OLD version from docs and rewrite
+      - name: Derive OLD version from python/README.md and rewrite
         run: |
           set -euo pipefail
-          # Scan docs/ + python/README.md for pinned semver of the form
-          # 2.x.y (and pre-release suffixes). Pick the highest as OLD —
-          # this tolerates a docs tree where most files already pin the
-          # current version and a few stragglers lag.
+          # Scan python/README.md for pinned semver of the form 2.x.y (and
+          # pre-release suffixes). Pick the highest as OLD — this tolerates
+          # a file where most pins are current and a few stragglers lag.
+          # (The Mintlify docs/ tree was retired from this repo; doc-version
+          # sync now lives in bithuman-product/public-docs.)
           TARGETS=()
-          [ -d docs ] && TARGETS+=("docs")
           [ -f python/README.md ] && TARGETS+=("python/README.md")
           if [ ${#TARGETS[@]} -eq 0 ]; then
-            echo "::error::no docs/ or python/README.md found in $DOCS_REPO"
+            echo "::error::no python/README.md found in $DOCS_REPO"
             exit 1
           fi
           OLD=$(grep -rhoE '\b2\.[0-9]+\.[0-9]+([a-z0-9]+)?\b' "${TARGETS[@]}" \
                   | sort -V | tail -n 1 || true)
           if [ -z "$OLD" ]; then
-            echo "::error::no 2.x.y pin found in ${TARGETS[*]} — nothing to bump"
-            exit 1
+            # No 2.x.y pin in python/README.md: nothing here tracks the
+            # libessence version anymore (the doc pins moved to the
+            # bithuman-product/public-docs repo). Treat as a clean no-op
+            # rather than a failure so release-triggered runs stay green.
+            echo "no 2.x.y pin in ${TARGETS[*]} — nothing to bump (doc-version sync lives in bithuman-product/public-docs)"
+            echo "SKIP=1" >> "$GITHUB_ENV"
+            exit 0
           fi
           echo "OLD=$OLD"
           echo "NEW=$VERSION"
@@ -177,7 +188,7 @@ jobs:
             cat > /tmp/pr_body.md <<EOF
           Automated docs version bump triggered by libessence-v${VERSION} publish in bithuman-sdk.
 
-          Replaced every occurrence of \`${OLD}\` with \`${VERSION}\` across \`docs/\` and \`python/README.md\`.
+          Replaced every occurrence of \`${OLD}\` with \`${VERSION}\` in \`python/README.md\`.
 
           Please review the diff before merging — sed is a blunt instrument and may catch unrelated \`${OLD}\` strings (e.g. in changelogs).
           EOF

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,9 @@
 
 ## Project Overview
 
-Public SDK repository for bitHuman, a real-time avatar animation platform. Audio in, lip-synced video out at 25 FPS. This repo contains the Swift SDK binary distribution (SwiftPM), Python SDK metadata, runnable examples for all platforms, and the docs.bithuman.ai source.
+Public SDK repository for bitHuman, a real-time avatar animation platform. Audio in, lip-synced video out at 25 FPS. This repo contains the Swift SDK binary distribution (SwiftPM), Python SDK metadata, and runnable examples for all platforms.
 
-The Swift SDK source and Python SDK compiled internals are in private repos. This repo is the public surface for integration, examples, and documentation.
+The Swift SDK source and Python SDK compiled internals are in private repos. The documentation site (docs.bithuman.ai) now lives in the `bithuman-product/public-docs` repo (Astro) — it was migrated out of this repo. This repo is the public surface for integration and examples.
 
 ## Key Files to Read First
 
@@ -13,8 +13,6 @@ The Swift SDK source and Python SDK compiled internals are in private repos. Thi
 | `AGENTS.md` | Full AI agent discovery guide (decision tree, API surface, patterns) |
 | `README.md` | Human-facing overview, install instructions, quick start |
 | `python/README.md` | Python SDK detailed docs (API surface, CLI, env vars, Expression) |
-| `docs/docs.json` | Mintlify nav tree, theme, SEO, redirects |
-| `docs/api-reference/openapi.yaml` | OpenAPI 3.1 spec for the REST API |
 | `Examples/AGENTS.md` | Examples-specific agent guide with decision tree |
 | `Package.swift` | Swift SDK binary target and hardware requirements |
 
@@ -30,18 +28,11 @@ Examples/               -- Runnable examples for every integration path
   rest-api/             -- curl and Python scripts for HTTP API
   integrations/         -- Next.js, Java, Gradio, offline Mac
   quickstart/           -- 2-minute try-it path
-docs/                   -- docs.bithuman.ai source (Mintlify MDX)
-  api-reference/        -- REST API docs + openapi.yaml
-  getting-started/      -- Quickstart, models, auth, pricing
-  guides/               -- Building avatars, deployment
-  sdks/                 -- Python, Swift, Kotlin SDK pages
-  examples/             -- Doc pages for each example category
-  integrations/         -- Flutter plugin
-  docs.json             -- Mintlify nav, theme, SEO, redirects
 ```
 
-`llms.txt` / `llms-full.txt` / `sitemap.xml` are Mintlify-generated at
-build time (served at docs.bithuman.ai, not committed source files).
+The documentation source (docs.bithuman.ai) is NOT in this repo — it was
+migrated to the `bithuman-product/public-docs` repo (Astro). Edit docs
+there, not here.
 
 ## How to Run Examples
 
@@ -76,12 +67,8 @@ export BITHUMAN_API_SECRET=your_secret
 bash validate.sh    # or any endpoint script
 ```
 
-### Docs (local preview)
-
-```bash
-cd docs && npx mintlify@latest dev
-# Requires Node 18+
-```
+> Docs (docs.bithuman.ai) are no longer in this repo — they live in the
+> `bithuman-product/public-docs` repo. Make documentation edits there.
 
 ## Code Conventions
 
@@ -97,7 +84,6 @@ cd docs && npx mintlify@latest dev
 
 - No automated test suite in this public repo (SDK source is private).
 - To validate examples: run them with a real API secret and a valid `.imx` model file.
-- To validate docs: `cd docs && npx mintlify@latest dev` and check for build errors.
 - To validate REST API calls: use the curl scripts in `Examples/rest-api/curl/` against `https://api.bithuman.ai`.
 - Use `bithuman info <path>` to inspect `.imx` model metadata.
 - Use `POST /v1/validate` to verify an API secret is valid.


### PR DESCRIPTION
Part of the tiered-architecture refactor (Stage A docs cleanup). The Mintlify `docs/` tree was retired (3bc13cc) and migrated to the public-docs repo (docs.bithuman.ai); `docs/` no longer exists in this repo.

- **`bump-docs.yml`**: remove the dead `[ -d docs ]` version-derivation branch; convert the now-sourceless 'derive OLD version' step into a clean SKIP no-op — it would otherwise `exit 1` and **hard-fail every release dispatch**. `python/README.md` path + the repository_dispatch/PR-open behavior preserved; comment notes doc-version pins now live in public-docs.
- **`CLAUDE.md`**: drop the stale `docs/` directory structure + `cd docs && npx mintlify dev` instructions; point doc edits at public-docs / docs.bithuman.ai.