### PR TITLE
examples(compare-tts): voice path → engine/voice

### DIFF
--- a/Examples/swift/compare-tts/Package.swift
+++ b/Examples/swift/compare-tts/Package.swift
@@ -7,7 +7,7 @@ import PackageDescription
 // a Mac without a mic.
 //
 // PRIVATE-SOURCE DEPENDENCY: this tool imports `MLXAudioTTS`, which is
-// re-exported by the `Voice` product of the bithuman-sdk `voice/`
+// re-exported by the `Voice` product of the bithuman-sdk `engine/voice/`
 // package (the vendored Blaizzy/mlx-audio-swift TTS stack). That stack
 // is NOT part of the public binary distribution, so this example cannot
 // build against the published SwiftPM package alone — it needs the
@@ -17,7 +17,7 @@ import PackageDescription
 //     ~/code/bithuman-sdk          (private; collaborator access)
 //     ~/code/bithuman-sdk-public   (this repo)
 //
-// The path dep below resolves voice/ via that sibling layout. External
+// The path dep below resolves engine/voice/ via that sibling layout. External
 // developers without private access should use the `Voice` API through
 // the `bitHumanKit` umbrella binary instead of this dev harness. See
 // README.md.
@@ -30,9 +30,9 @@ let package = Package(
         .package(url: "https://github.com/ml-explore/mlx-swift", .upToNextMinor(from: "0.31.3")),
         .package(url: "https://github.com/ml-explore/mlx-swift-lm", from: "3.31.3"),
         // Private-source path dep — see the header note. Resolves the
-        // `voice/` SwiftPM package (product "Voice") via the sibling
+        // `engine/voice/` SwiftPM package (product "Voice") via the sibling
         // bithuman-sdk checkout.
-        .package(name: "voice", path: "../../../../bithuman-sdk/voice"),
+        .package(name: "voice", path: "../../../../bithuman-sdk/engine/voice"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/swift/compare-tts/README.md
+++ b/Examples/swift/compare-tts/README.md
@@ -24,8 +24,8 @@ monorepo. Clone it as a **sibling** of this repo:
 ~/code/bithuman-sdk-public   # this repo
 ```
 
-The `Package.swift` path dep (`../../../../bithuman-sdk/voice`) resolves
-`voice/` via that layout.
+The `Package.swift` path dep (`../../../../bithuman-sdk/engine/voice`) resolves
+`engine/voice/` via that layout.
 
 External developers without private access should reach the TTS stack
 through the published `bitHumanKit` umbrella binary instead of this tool.


### PR DESCRIPTION
Companion to bithuman-sdk #65 (voice→engine/voice, merged). The `compare-tts` dev harness path-deps the private SDK's `Voice` package via the sibling layout; repoint `../../../../bithuman-sdk/voice` → `.../engine/voice`.

The file header already documents this as an **internal dev harness** that needs a sibling private `bithuman-sdk` checkout (external developers use the `Voice` API via the published `bitHumanKit` umbrella instead). The long-term fix — switching to a published `Voice` xcframework binaryTarget so the public mirror can build it standalone — is **release-gated** (needs the Voice xcframework + checksum published first) and tracked separately.