### PR TITLE
docs(examples): fix bench-essence dissolved-package name + dedupe API-key onboarding

### DIFF
--- a/Examples/README.md
+++ b/Examples/README.md
@@ -50,10 +50,7 @@ If you want to understand bitHuman deeply, follow these examples in order:
 
 ## How authentication works
 
-You need an API key to use bitHuman. It's free to sign up (99 credits/month, no credit card).
-
-1. Go to [www.bithuman.ai](https://www.bithuman.ai) and create an account
-2. Click **Developer** → **API Keys** and copy your secret
+You need a free API key to run any example. See [API-key setup in the root README](../README.md#before-you-start) for how to get one and which variable name each SDK uses.
 
 Then set it as an environment variable before running any example:
 
@@ -64,8 +61,6 @@ export BITHUMAN_API_SECRET="paste_your_key_here"
 # For Swift examples (different variable name, same key):
 export BITHUMAN_API_KEY="paste_your_key_here"
 ```
-
-> **Why two different variable names?** The Python SDK was built first and used `BITHUMAN_API_SECRET`. The Swift SDK came later and uses `BITHUMAN_API_KEY`. They're the same credential from the same dashboard — just different names for historical reasons. We know it's confusing. Use the right one for your SDK.
 
 ## Two avatar models
 

--- a/Examples/swift/bench-essence/Sources/BenchEssence/main.swift
+++ b/Examples/swift/bench-essence/Sources/BenchEssence/main.swift
@@ -1088,7 +1088,7 @@ func runBench(args: CLIArgs) async throws {
 
     let meta = Meta(
         sdk: "swift",
-        sdk_version: bitHumanKitVersion(),
+        sdk_version: bithumanSDKVersion(),
         host: hostInfo(),
         fixture: MetaFixture(
             imx_path: fixture.path,
@@ -1135,13 +1135,14 @@ func runBench(args: CLIArgs) async throws {
 }
 
 /// SDK version string. There's no compile-time bake of the SemVer in
-/// `bitHumanKit`; Swift surfaces the resolved Package.resolved tag at
-/// build time only. The bench harness reports the value embedded in
-/// `Package.swift` minor pin notation, which is consistent across the
+/// the `Bithuman` product; Swift surfaces the resolved Package.resolved
+/// tag at build time only. The bench harness reports the value embedded
+/// in `Package.swift` minor pin notation, which is consistent across the
 /// matrix of binaries we ship from this repo.
-func bitHumanKitVersion() -> String {
-    // TODO when bitHumanKit exposes a static `version` constant, swap
-    // this. For now the value is hand-aligned to the latest tag.
+func bithumanSDKVersion() -> String {
+    // TODO when the `Bithuman` product exposes a static `version`
+    // constant, swap this. For now the value is hand-aligned to the
+    // latest tag.
     "0.10.0"
 }
 


### PR DESCRIPTION
- **bench-essence**: rename `bitHumanKitVersion()` → `bithumanSDKVersion()` + reword the comment/TODO (`bitHumanKit` was dissolved; the bench drives the `Bithuman` product). `import bitHumanKit` kept — it's the current public SwiftPM umbrella product (v0.8.1), not stale.
- **Examples/README.md**: replace the restated API-key credit/key-name boilerplate with a pointer to the root README (canonical), keeping the example-specific `export` usage.