### PR TITLE
docs(mirror): fix broken quickstart snippets + stale CLI command set

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,8 +61,8 @@ curl -fsSL https://github.com/bithuman-product/homebrew-bithuman/releases/latest
 # Or macOS Homebrew
 brew install bithuman-product/bithuman/bithuman-cli
 
-bithuman avatar      # browser-served avatar at http://127.0.0.1:8080
-bithuman voice       # spoken conversation in the terminal
+bithuman init        # first-time setup (API key, brain, default avatar)
+bithuman run         # live, lip-synced avatar in your browser
 ```
 
 ### REST API
@@ -137,15 +137,13 @@ All requests require `api-secret: YOUR_SECRET` header.
 
 | Command | Purpose |
 |---|---|
-| `bithuman doctor` | Verify host + API key |
-| `bithuman avatar` | Browser-served avatar at `http://127.0.0.1:8080` |
-| `bithuman voice` | Spoken conversation in the terminal |
-| `bithuman text` | Text chat, stdin → stdout |
-| `bithuman generate <model> --audio <file> -o out.mp4` | Render lip-synced MP4 |
-| `bithuman stream <model>` | Start local HTTP streaming server |
-| `bithuman speak <audio>` | Send audio to a running stream server |
+| `bithuman init` | First-time setup wizard (API key, brain, default avatar) |
+| `bithuman run [model]` | Run the live avatar — embedded LiveKit + brain + browser UI at `http://127.0.0.1:8088` |
+| `bithuman render <model> -a <audio> -o out.mp4` | Offline render a lip-synced MP4 |
+| `bithuman pull <slug>` | Download a showcase avatar into the local cache |
+| `bithuman list` | Browse showcase avatars + cache state |
 | `bithuman info <model>` | Show `.imx` model metadata |
-| `bithuman models list` | List downloadable showcase avatars |
+| `bithuman doctor` | Host capability check (versions, RAM, API key, brain) |
 
 ## Common Patterns
 

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -50,10 +50,7 @@ If you want to understand bitHuman deeply, follow these examples in order:
 
 ## How authentication works
 
-You need an API key to use bitHuman. It's free to sign up (99 credits/month, no credit card).
-
-1. Go to [www.bithuman.ai](https://www.bithuman.ai) and create an account
-2. Click **Developer** → **API Keys** and copy your secret
+You need a free API key to run any example. See [API-key setup in the root README](../README.md#before-you-start) for how to get one and which variable name each SDK uses.
 
 Then set it as an environment variable before running any example:
 
@@ -64,8 +61,6 @@ export BITHUMAN_API_SECRET="paste_your_key_here"
 # For Swift examples (different variable name, same key):
 export BITHUMAN_API_KEY="paste_your_key_here"
 ```
-
-> **Why two different variable names?** The Python SDK was built first and used `BITHUMAN_API_SECRET`. The Swift SDK came later and uses `BITHUMAN_API_KEY`. They're the same credential from the same dashboard — just different names for historical reasons. We know it's confusing. Use the right one for your SDK.
 
 ## Two avatar models
 

--- a/Examples/swift/README.md
+++ b/Examples/swift/README.md
@@ -80,7 +80,7 @@ For quick testing without writing code, install the CLI via Homebrew:
 
 ```bash
 brew install bithuman-product/bithuman/bithuman-cli
-bithuman avatar
+bithuman run
 ```
 
 See [docs.bithuman.ai/getting-started/cli](https://docs.bithuman.ai/getting-started/cli) for usage.

--- a/Examples/swift/bench-essence/Sources/BenchEssence/main.swift
+++ b/Examples/swift/bench-essence/Sources/BenchEssence/main.swift
@@ -1088,7 +1088,7 @@ func runBench(args: CLIArgs) async throws {
 
     let meta = Meta(
         sdk: "swift",
-        sdk_version: bitHumanKitVersion(),
+        sdk_version: bithumanSDKVersion(),
         host: hostInfo(),
         fixture: MetaFixture(
             imx_path: fixture.path,
@@ -1135,13 +1135,14 @@ func runBench(args: CLIArgs) async throws {
 }
 
 /// SDK version string. There's no compile-time bake of the SemVer in
-/// `bitHumanKit`; Swift surfaces the resolved Package.resolved tag at
-/// build time only. The bench harness reports the value embedded in
-/// `Package.swift` minor pin notation, which is consistent across the
+/// the `Bithuman` product; Swift surfaces the resolved Package.resolved
+/// tag at build time only. The bench harness reports the value embedded
+/// in `Package.swift` minor pin notation, which is consistent across the
 /// matrix of binaries we ship from this repo.
-func bitHumanKitVersion() -> String {
-    // TODO when bitHumanKit exposes a static `version` constant, swap
-    // this. For now the value is hand-aligned to the latest tag.
+func bithumanSDKVersion() -> String {
+    // TODO when the `Bithuman` product exposes a static `version`
+    // constant, swap this. For now the value is hand-aligned to the
+    // latest tag.
     "0.10.0"
 }
 

--- a/README.md
+++ b/README.md
@@ -95,14 +95,26 @@ bithuman run                                          # auto-downloads a demo av
 # → http://127.0.0.1:8088/<code> — open in browser, click mic, talk
 ```
 
-`bithuman run` is the full talk-to-your-avatar stack — embedded livekit-server + agent-worker brain + browser UI — from one command. For offline rendering and other modes, see [docs.bithuman.ai/getting-started/cli](https://docs.bithuman.ai/getting-started/cli).
+`bithuman run` is the full talk-to-your-avatar stack — embedded livekit-server + agent-worker brain + browser UI — from one command. For offline rendering and other modes, see [docs.bithuman.ai/cli](https://docs.bithuman.ai/cli).
 
 ## Quick start (Python)
 
 ```python
 import asyncio, os
+import numpy as np
+import soundfile as sf
 from bithuman import AsyncBithuman
-from bithuman.audio import load_audio, float32_to_int16
+
+# bithuman 2.3 is library-only — the old bithuman.audio helpers were
+# removed. Inline what we need (the SDK resamples to 16 kHz internally).
+def load_audio(path):
+    audio, sr = sf.read(path, dtype="float32", always_2d=False)
+    if audio.ndim > 1:
+        audio = audio.mean(axis=1)
+    return audio, sr
+
+def float32_to_int16(arr):
+    return (np.clip(arr, -1.0, 1.0) * 32767.0).astype(np.int16)
 
 async def main():
     # 1. Load the avatar model and connect to the billing API
@@ -116,7 +128,7 @@ async def main():
     pcm = float32_to_int16(pcm)
     chunk = sr // 25                                       # one chunk per frame
     for i in range(0, len(pcm), chunk):
-        await runtime.push_audio(pcm[i : i + chunk].tobytes(), sr)
+        await runtime.push_audio(pcm[i : i + chunk].tobytes(), sr, last_chunk=False)
     await runtime.flush()                                  # signal "audio is done"
 
     # 3. Pull video frames — each frame is a numpy image

--- a/python/README.md
+++ b/python/README.md
@@ -173,17 +173,15 @@ Every command reads `$BITHUMAN_API_SECRET` by default.
 
 | Command | Description |
 |---------|-------------|
-| `bithuman doctor` | Verify host + API key |
-| `bithuman avatar` | Browser-served avatar at `http://127.0.0.1:8080` |
-| `bithuman voice` | Spoken conversation in the terminal |
-| `bithuman text` | Text chat, stdin → stdout |
-| `bithuman generate <model> --audio <file> -o out.mp4` | Render a lip-synced MP4 |
-| `bithuman stream <model>` | Local HTTP streaming server |
-| `bithuman speak <audio>` | Send audio to a running `stream` server |
+| `bithuman init` | First-time setup wizard (API key, brain, default avatar) |
+| `bithuman run [model]` | Run the live avatar — embedded LiveKit + brain + browser UI at `http://127.0.0.1:8088` |
+| `bithuman render <model> -a <audio> -o out.mp4` | Offline render a lip-synced MP4 |
+| `bithuman pull <slug>` | Download a showcase avatar into the local cache |
+| `bithuman list` | Browse showcase avatars + cache state |
 | `bithuman info <model>` | Show `.imx` model metadata |
-| `bithuman models list` | List downloadable showcase avatars |
+| `bithuman doctor` | Host capability check (versions, RAM, API key, brain) |
 
-Full reference: [docs.bithuman.ai/getting-started/cli](https://docs.bithuman.ai/getting-started/cli)
+Full reference: [docs.bithuman.ai/cli](https://docs.bithuman.ai/cli)
 
 ## Environment variables
 

--- a/swift/README.md
+++ b/swift/README.md
@@ -91,10 +91,9 @@ Sign in at [www.bithuman.ai](https://www.bithuman.ai) → Developer → API Keys
 ## CLI (no code)
 
 ```bash
-brew install bithuman-product/bithuman/bithuman
-bithuman avatar           # voice + lip-synced avatar in your browser
-bithuman-cli text         # type to chat
-bithuman-cli              # voice mode (default)
+brew install bithuman-product/bithuman/bithuman-cli
+bithuman init             # first-time setup (API key, brain, default avatar)
+bithuman run              # live, lip-synced avatar in your browser
 ```
 
 ## Examples
@@ -110,14 +109,10 @@ Working SwiftUI example projects live in [`Examples/swift/`](../Examples/swift/)
 
 ## Documentation
 
-- [Swift SDK overview](https://docs.bithuman.ai/swift-sdk/overview)
-- [10-min quickstart](https://docs.bithuman.ai/swift-sdk/quickstart)
-- [macOS deployment](https://docs.bithuman.ai/swift-sdk/macos)
-- [iOS / iPadOS deployment](https://docs.bithuman.ai/swift-sdk/ios)
-- [Essence on Swift](https://docs.bithuman.ai/swift-sdk/essence)
-- [bithuman-cli](https://docs.bithuman.ai/swift-sdk/cli)
-- [Troubleshooting](https://docs.bithuman.ai/swift-sdk/troubleshooting)
-- [Pricing & credits](https://docs.bithuman.ai/getting-started/pricing)
+- [Swift SDK guide](https://docs.bithuman.ai/sdk/swift) — overview, macOS/iOS deployment, and Essence on Swift
+- [iOS / iPadOS example](https://docs.bithuman.ai/examples/swift-ios-hello)
+- [CLI](https://docs.bithuman.ai/cli)
+- [Pricing & credits](https://docs.bithuman.ai/guides/pricing)
 
 ## Source code & support
 


### PR DESCRIPTION
Fixes broken/out-of-box-failing content in the public mirror, verified
against the shipped 2.3.x SDK + Rust CLI (`run/render/info/pull/list/doctor/
init`):

- **README quickstart** imported the removed `bithuman.audio` module
  (ModuleNotFoundError) and pushed every chunk with the default
  `last_chunk=True` (marks end-of-speech per chunk). Inlined the
  `load_audio`/`float32_to_int16` helpers and set `last_chunk=False`.
- **`python/README.md`, `AGENTS.md`, `swift/README.md`,
  `Examples/swift/README.md`** documented fantasy CLI subcommands
  (`avatar`/`voice`/`text`/`generate`/`stream`/`speak`/`models`) that don't
  exist. Replaced with the real command set.
- **`swift/README.md`** installed the wrong brew formula (`.../bithuman` →
  `.../bithuman-cli`) and linked a dead `/swift-sdk/*` doc scheme; repointed
  to live routes (`/sdk/swift`, `/examples/swift-ios-hello`, `/cli`,
  `/guides/pricing`).

(`/getting-started/*` links 308-redirect on the live site, so they still
resolve — left as-is.)

Note: includes a pre-existing commit on this branch (dissolved-package-name
fix in bench-essence + API-key onboarding dedupe).
