### PR TITLE
docs: mirror coherence — versions, ABI v7, MCP notes

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -11,6 +11,8 @@ It's a thin, fully-documented wrapper over the public REST API
 
 ## Tools
 
+The server exposes **21 tools**, each mapping to one documented REST endpoint:
+
 | Tool | What it does |
 |------|--------------|
 | `validate_api_secret` | Check the API secret is valid (free). |


### PR DESCRIPTION
Coherence audit of the public SDK mirror + MCP server repo against the agreed 2026-06-02 API/versioning contract. Doc-only, surgical.

## Change
- **mcp/README.md** — state explicitly that the server exposes **21 tools** (not 14). The Tools table already lists all 21; the added count line makes it unambiguous and matches `mcp/src/bithuman_mcp/server.py`, which registers exactly 21 `@mcp.tool()` functions.

## Verified already-correct (no edit needed — recorded for the audit)
- **ABI** — docs already say "libessence ABI v7" (`Examples/cli/README.md`, `Examples/cli/render-video.sh`); no stale `ABI v6` literal exists anywhere in the mirror.
- **Versions** — the libessence engine core axis is kept distinct from the SDK/CLI/monorepo line. The Swift package is on its own `0.8.x` SemVer axis and was deliberately left untouched (it is not the 2.3.x line). No false rewrite to `2.3.6` was introduced; the `As of bithuman 2.3.0 / libessence ABI v7` cli note is a feature-introduction marker, not a current-version claim, so it was preserved. No doc currently states `libessence 1.19.1`, so nothing was misstated to correct.
- **Examples (private sibling)** — `Examples/swift/compare-tts` already documents the private `bithuman-sdk` sibling-checkout prerequisite in both its README and `Package.swift` header. It is the only example with a private sibling path dep; `compare-dit` and `compare-llm` build against the public SwiftPM package / public OSS packages, so no prerequisite note was added.

## Note (optional item B, not actioned)
The running MCP server's `serverInfo.version` surfaces the FastMCP library version, not the `bithuman-mcp` package version `0.2.1`. `FastMCP("bitHuman", ...)` is constructed without an explicit `version=`. Setting it is plausibly trivial, but the `mcp` package was not importable in this environment so I could not verify the installed FastMCP accepts a `version` kwarg — left unchanged to avoid risking the server. Flagging for a follow-up that can verify the kwarg.

Generated as part of the 2026-06-02 coherence audit.