### PR TITLE
mcp: deprecate bithuman-mcp → built-in `bithuman mcp`

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,5 +1,20 @@
 # bitHuman MCP server
 
+> [!IMPORTANT]
+> **Deprecated — use the bitHuman CLI instead.** This server is now built into
+> the [`bithuman` CLI](https://github.com/bithuman-product/homebrew-bithuman):
+> run **`bithuman mcp`**. It exposes the same tools (identical names) plus local
+> ones (`version`, `doctor`, `inspect_model`, `list_showcase`), so you install
+> **one** tool. Migrate your MCP client config:
+>
+> ```json
+> { "mcpServers": { "bithuman": { "command": "bithuman", "args": ["mcp"] } } }
+> ```
+>
+> Install the CLI: `brew install bithuman` (macOS) or the universal installer
+> (macOS + Linux) — see the CLI README. This `bithuman-mcp` package will receive
+> no further updates.
+
 A [Model Context Protocol](https://modelcontextprotocol.io) server that exposes
 the [bitHuman](https://bithuman.ai) avatar platform as tools any MCP-capable AI
 agent can call — Claude Desktop, Claude Code, Cursor, and others.

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,13 +1,14 @@
 [project]
 name = "bithuman-mcp"
-version = "0.2.1"
-description = "Model Context Protocol server for the bitHuman AI avatar platform"
+version = "0.3.0"
+description = "DEPRECATED — use `bithuman mcp` in the bitHuman CLI. MCP server for the bitHuman AI avatar platform."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 authors = [{ name = "bitHuman", email = "support@bithuman.ai" }]
 keywords = ["bithuman", "mcp", "model-context-protocol", "avatar", "ai", "tts", "agent"]
 classifiers = [
+    "Development Status :: 7 - Inactive",
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",

--- a/mcp/src/bithuman_mcp/server.py
+++ b/mcp/src/bithuman_mcp/server.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import base64
 import os
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -457,6 +458,15 @@ async def test_webhook(webhook_id: str) -> dict:
 
 def main() -> None:
     """Entry point. Serves over stdio (default) or streamable-http."""
+    # Deprecation notice → stderr only (never stdout, which carries the
+    # stdio JSON-RPC stream). This package is superseded by the built-in
+    # `bithuman mcp` server in the bitHuman CLI.
+    print(
+        "bithuman-mcp is deprecated — the MCP server is now built into the "
+        "bitHuman CLI. Install it (`brew install bithuman` or the universal "
+        "installer) and run `bithuman mcp`. Same tools, one tool to install.",
+        file=sys.stderr,
+    )
     transport = os.environ.get("BITHUMAN_MCP_TRANSPORT", "stdio")
     mcp.run(transport=transport)  # type: ignore[arg-type]
 


### PR DESCRIPTION
The MCP server is now **built into the bitHuman CLI** (`bithuman mcp`) — same
tools with identical names, plus local tools the REST API can't provide
(`version`, `doctor`, `inspect_model`, `list_showcase`). Developers and AI
agents install **one** tool.

This PR marks the standalone `bithuman-mcp` Python package as deprecated:
- **README** — prominent deprecation banner + MCP-client config migration:
  `{ "mcpServers": { "bithuman": { "command": "bithuman", "args": ["mcp"] } } }`
- **server.py** — a stderr deprecation notice at startup (kept off stdout,
  which carries the stdio JSON-RPC stream).
- **pyproject** — `version = 0.3.0`, `Development Status :: 7 - Inactive`,
  description prefixed `DEPRECATED`.

CLI implementation (merged): bithuman-product/bithuman-apps#76.

**Note:** this does not publish anything. A PyPI deprecation release of
`bithuman-mcp==0.3.0` is a separate, manual step pending the maintainer's
go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)