### PR TITLE
docs: repoint private-source refs bithuman-sdk -> bithuman-sdk-internal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,11 +236,11 @@ The bitHuman platform spans three repos, each owning one layer of the stack:
 
 | Repo | Visibility | Layer | What it contains |
 |------|-----------|-------|------------------|
-| **bithuman-sdk** | Private | Engine + SDKs | `libessence` engine + Python / Swift / Kotlin / Rust language bindings (source). Publishes the binary wheels / xcframework / AAR. |
+| **bithuman-sdk-internal** | Private | Engine + SDKs | `libessence` engine + Python / Swift / Kotlin / Rust language bindings (source). Publishes the binary wheels / xcframework / AAR. |
 | **bithuman-apps** | Private | Apps | CLI (`bithuman-cli` on PyPI, Homebrew formula source), Flutter plugin, reference apps (Mac, iPad, iPhone). Each consumes the SDKs the same way any third-party would. |
 | **bithuman-sdk-public** | Public | Landing pages + examples | SwiftPM facade for the binary release, `python/` PyPI landing, runnable `Examples/`. (The `docs.bithuman.ai` site source now lives in the `bithuman-product/public-docs` repo, not here.) |
 
-Reference apps and the CLI do **not** live inside `bithuman-sdk-public` or `bithuman-sdk`. They are in `bithuman-apps` and depend on the SDKs as normal downstream consumers.
+Reference apps and the CLI do **not** live inside `bithuman-sdk-public` or `bithuman-sdk-internal`. They are in `bithuman-apps` and depend on the SDKs as normal downstream consumers.
 
 ### bithuman-sdk-public
 

--- a/Examples/swift/README.md
+++ b/Examples/swift/README.md
@@ -24,7 +24,7 @@ These are lower-level harnesses (benchmarks, A/B comparisons, a server daemon) c
 | [hello-voice-chat/](hello-voice-chat/) | `bitHumanKit` | The smallest possible SPM executable embedding the SDK: `VoiceChat` + `VoiceChatConfig`, no avatar, no billing. |
 | [compare-quality/](compare-quality/) | `Expression` | Render a WAV → lip-synced MP4 to A/B fp16 vs int4 animator quality. Targets the Layer-1 Expression engine directly. |
 | [compare-llm/](compare-llm/) | upstream MLX OSS | Load each on-device LLM (iOS vs macOS split) on a fixed prompt set. No bitHuman binary — same OSS path as `LLMClient`. |
-| [compare-tts/](compare-tts/) | `Voice` (private source) | Load Kokoro + Qwen3-TTS and synthesize a fixed utterance. **Requires the private bithuman-sdk sibling checkout** (see its README). |
+| [compare-tts/](compare-tts/) | `Voice` (private source) | Load Kokoro + Qwen3-TTS and synthesize a fixed utterance. **Requires the private bithuman-sdk-internal sibling checkout** (see its README). |
 | [bench-essence/](bench-essence/) | `bitHumanKit` | Essence runtime perf + correctness bench. Full correctness path needs an internal test seam (see its README). |
 | [essence-server/](essence-server/) | `bitHumanKit` + LiveKit + Hummingbird | Native Swift LiveKit avatar service: hosts N runtimes behind HTTP `/launch`, republishes video + audio. |
 

--- a/Examples/swift/compare-tts/Package.swift
+++ b/Examples/swift/compare-tts/Package.swift
@@ -7,14 +7,14 @@ import PackageDescription
 // a Mac without a mic.
 //
 // PRIVATE-SOURCE DEPENDENCY: this tool imports `MLXAudioTTS`, which is
-// re-exported by the `Voice` product of the bithuman-sdk `engine/voice/`
+// re-exported by the `Voice` product of the bithuman-sdk-internal `engine/voice/`
 // package (the vendored Blaizzy/mlx-audio-swift TTS stack). That stack
 // is NOT part of the public binary distribution, so this example cannot
 // build against the published SwiftPM package alone — it needs the
-// private monorepo `bithuman-product/bithuman-sdk` cloned as a SIBLING
+// private monorepo `bithuman-product/bithuman-sdk-internal` cloned as a SIBLING
 // of this repo:
 //
-//     ~/code/bithuman-sdk          (private; collaborator access)
+//     ~/code/bithuman-sdk-internal          (private; collaborator access)
 //     ~/code/bithuman-sdk-public   (this repo)
 //
 // The path dep below resolves engine/voice/ via that sibling layout. External
@@ -31,8 +31,8 @@ let package = Package(
         .package(url: "https://github.com/ml-explore/mlx-swift-lm", from: "3.31.3"),
         // Private-source path dep — see the header note. Resolves the
         // `engine/voice/` SwiftPM package (product "Voice") via the sibling
-        // bithuman-sdk checkout.
-        .package(name: "voice", path: "../../../../bithuman-sdk/engine/voice"),
+        // bithuman-sdk-internal checkout.
+        .package(name: "voice", path: "../../../../bithuman-sdk-internal/engine/voice"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/swift/compare-tts/README.md
+++ b/Examples/swift/compare-tts/README.md
@@ -13,18 +13,18 @@ Backends exercised:
 ## Private-source dependency
 
 This example imports `MLXAudioTTS`, re-exported by the `Voice` product of
-the bithuman-sdk `voice/` package (the vendored
+the bithuman-sdk-internal `voice/` package (the vendored
 [Blaizzy/mlx-audio-swift](https://github.com/Blaizzy/mlx-audio-swift) TTS
 stack, MIT). That stack is **not** part of the public binary
 distribution, so this dev harness can only build against the private
 monorepo. Clone it as a **sibling** of this repo:
 
 ```
-~/code/bithuman-sdk          # private (collaborator access)
+~/code/bithuman-sdk-internal          # private (collaborator access)
 ~/code/bithuman-sdk-public   # this repo
 ```
 
-The `Package.swift` path dep (`../../../../bithuman-sdk/engine/voice`) resolves
+The `Package.swift` path dep (`../../../../bithuman-sdk-internal/engine/voice`) resolves
 `engine/voice/` via that layout.
 
 External developers without private access should reach the TTS stack
@@ -44,4 +44,4 @@ load time, gen time, RTF, |mean| and peak amplitude per backend.
 ## Requires
 
 - macOS 26+ (Tahoe), Apple Silicon
-- The private bithuman-sdk sibling checkout (see above)
+- The private bithuman-sdk-internal sibling checkout (see above)

--- a/Package.swift
+++ b/Package.swift
@@ -2,12 +2,12 @@
 // bitHumanKit — public binary distribution.
 //
 // The source for these frameworks lives in the private monorepo
-// bithuman-product/bithuman-sdk (the swift/ tree for bitHumanKit; the
+// bithuman-product/bithuman-sdk-internal (the swift/ tree for bitHumanKit; the
 // engine/expression/ and sdks/swift/ trees for the two Layer-1 engine
 // products extracted on the refactor/engine-tiers branch). This package
 // consumes the pre-compiled XCFrameworks attached to THIS repo's GitHub
 // Releases via SwiftPM's binaryTarget — each `.xcframework.zip` is built
-// from bithuman-sdk and uploaded here per release; consumers depend only
+// from bithuman-sdk-internal and uploaded here per release; consumers depend only
 // on this package URL.
 //
 // All third-party deps (MLX, HuggingFace, Tokenizers, …) are
@@ -24,7 +24,7 @@
 //   - Expression   Layer-1 avatar engine on its own: speech encoder →
 //                  animator → face decoder → face renderer expressive
 //                  talking head. Built from the
-//                  bithuman-sdk engine/expression/ package. Pull this in
+//                  bithuman-sdk-internal engine/expression/ package. Pull this in
 //                  directly when you only need the avatar renderer (no
 //                  STT/LLM/TTS). Home of the `Bithuman` actor,
 //                  `Bithuman.Quality`, `AvatarConfig`, `ImxContainer`.
@@ -32,7 +32,7 @@
 //   - Bithuman     Layer-1 Essence engine on its own: the portable
 //                  libessence C++ avatar runtime (audio → composited BGR
 //                  frames from a pre-built `.imx`). Built from the
-//                  bithuman-sdk sdks/swift/ package. CPU-only, works on
+//                  bithuman-sdk-internal sdks/swift/ package. CPU-only, works on
 //                  any Apple Silicon. `import Bithuman`.
 //
 // Hardware floor (gated at runtime via HardwareCheck.evaluate()):


### PR DESCRIPTION
The private source monorepo was renamed `bithuman-product/bithuman-sdk` → `bithuman-product/bithuman-sdk-internal` (301-redirecting, nothing broken). Updates this public mirror's references to the private source for clarity and to keep the `compare-tts` sibling-checkout instructions self-consistent.

## Changed
- **`Package.swift`** — "built from bithuman-sdk-internal" + the engine/expression and sdks/swift source-package mentions + org-qualified URL comment.
- **`Examples/swift/compare-tts/Package.swift`** + **`README.md`** — the sibling-checkout `path:` dep (`../../../../bithuman-sdk-internal/engine/voice`), the `~/code/bithuman-sdk-internal` clone instructions, and prose.
- **`Examples/swift/README.md`** — "private bithuman-sdk-internal sibling checkout".
- **`AGENTS.md`** — repo table row + "do not live inside ... bithuman-sdk-internal".

## Left intact (intentional)
- All `bithuman-sdk-public` references (this repo).
- `python/CHANGELOG.md` historical entry.
- `.github/CODEOWNERS` comment (refers to this public repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)